### PR TITLE
Alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.7] - 2026-05-06
+
+Seventh **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.7`** (tag **`v0.5.0-alpha.7`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Insignia card** (`0.2.8`): modo **solo icono** — **`align-self: center`** por defecto (variable **`--insignia-icon-only-align-self`**, p. ej. **`stretch`** en franjas con scroll); **`translateY`** fino con **`--insignia-icon-only-row-nudge`** (por defecto **`-2px`**).
+- **Internals** (**`nodalia-utils.js`**): **`initNodaliaUtils`** solo hace **early return** si existe la **API completa** en **`window.NodaliaUtils`**; **`editorFilteredStatesSignature`** vuelve a incluir **filas por entidad** (**`id`**, **`friendly_name`**, **`icon`**) para que los editores detecten cambios en etiquetas.
+
+---
+
 ## [0.5.0-alpha.6] - 2026-05-05
 
 Sixth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.6`** (tag **`v0.5.0-alpha.6`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,19 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.8] - 2026-05-06
+
+Eighth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.8`** (tag **`v0.5.0-alpha.8`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+Mismo contenido funcional que **`alpha.7`** con **Insignia** **`0.2.9`** y utilidades **`nodalia-utils`**: número de prerelease subido para etiquetar el bundle corregido (**`nodalia-cards.js`** parseable; ver **`alpha.7`**).
+
+---
+
 ## [0.5.0-alpha.7] - 2026-05-06
 
 Seventh **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.7`** (tag **`v0.5.0-alpha.7`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
 
-- **Insignia card** (`0.2.8`): modo **solo icono** — **`align-self: center`** por defecto (variable **`--insignia-icon-only-align-self`**, p. ej. **`stretch`** en franjas con scroll); **`translateY`** fino con **`--insignia-icon-only-row-nudge`** (por defecto **`-2px`**).
+- **Insignia card** (`0.2.9`): modo **solo icono** — **`align-self: center`** por defecto (variable **`--insignia-icon-only-align-self`**, p. ej. **`stretch`** en franjas con scroll); **`translateY`** fino con **`--insignia-icon-only-row-nudge`** (por defecto **`-2px`**). Corrección: comentario CSS sin **backticks** dentro del **`innerHTML`** en plantilla JS — en **`0.2.8`** rompían el parseo de **`nodalia-cards.js`** y las tarjetas **custom** no se registraban.
 - **Internals** (**`nodalia-utils.js`**): **`initNodaliaUtils`** solo hace **early return** si existe la **API completa** en **`window.NodaliaUtils`**; **`editorFilteredStatesSignature`** vuelve a incluir **filas por entidad** (**`id`**, **`friendly_name`**, **`icon`**) para que los editores detecten cambios en etiquetas.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.9] - 2026-05-05
+
+Ninth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.9`** (tag **`v0.5.0-alpha.9`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Graph card** (`0.12.19`): vista **estrecha** (`max-width: 640px`) — **valor y chips de leyenda** en la **misma fila**; leyenda con **scroll horizontal** si hace falta (ya no se fuerza **`flex-wrap`** de la fila ni **`100%`** de ancho en la leyenda, evitando solaparse con el **chart**).
+- **Insignia card** (`0.2.10`): modo **solo icono** — **`border-radius`** del contenedor alineado con **`styles.card.border_radius`** (igual que la píldora con nombre/valor); **`inherit`** en contenido, icono e **imagen**.
+- **Standalone scripts:** **`nodalia-utils.js`** incrustado al inicio de cada tarjeta **`nodalia-*.js`** que usa **`window.NodaliaUtils`** (marcadores **`nodalia-standalone-utils`**); **`npm run bundle`** lo **elimina** del **`nodalia-cards.js`** para no duplicar. **`nodalia-bubble-contrast.js`** no lleva embed (no usa **`NodaliaUtils`**).
+- **Tooling** (**`scripts/sync-standalone-embed.mjs`**): sincronización **idempotente** — tras **`</nodalia-standalone-utils>`** se eliminan **todos** los saltos de línea iniciales (round-trip estable con **`wrapEmbed`**); comparación con **`CRLF`** normalizado a **`LF`**, de modo que **`npm run bundle`** no reescribe en masa los **`nodalia-*.js`** cuando **`nodalia-utils.js`** no cambia.
+
+---
+
 ## [0.5.0-alpha.8] - 2026-05-06
 
 Eighth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.8`** (tag **`v0.5.0-alpha.8`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.11] - 2026-05-06
+
+Eleventh **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.11`** (tag **`v0.5.0-alpha.11`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Insignia card** (`0.2.12`): modo **solo icono** — misma **`.insignia-card__content`** que la píldora (**`styles.card.padding`** / **`gap`** / disco **`iconSizePx`**); **sin** segunda columna vacía ni cuadrado fijo; disco del icono como en modo con texto; **`padding-block`** del **`:host`** otra vez **`4px`** por defecto en franjas con scroll (**`--insignia-scroll-strip-*`**).
+
+---
+
 ## [0.5.0-alpha.10] - 2026-05-06
 
 Tenth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.10`** (tag **`v0.5.0-alpha.10`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.4] - 2026-05-05
+
+Fourth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.4`** (tag **`v0.5.0-alpha.4`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Graph card** (`0.12.16`): **`DEFAULT_CONFIG`** y **`STUB`** orientados a **temperatura** — entidades de ejemplo, **`min`** / **`max`** **`15`**–**`25`**, **`points`** **`100`**, **`styles.card`** **`padding`** **`18px`**, **`gap`** **`20px`**, **`icon.size`** **`20px`**; placeholder del editor **Temperatura**. Ejemplo en **`examples/graph-card.yaml`**.
+- **Insignia card** (`0.2.4`): modo **solo icono** — **`margin-block`** en **`:host`** (por defecto **`8px`**, sobreescribible con **`--insignia-scroll-strip-margin-block`**) para que las **franjas con scroll horizontal** no recorten el círculo; estado vacío limpia **`data-icon-only`**.
+
+---
+
 ## [0.5.0-alpha.3] - 2026-05-05
 
 Third **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.3`** (tag **`v0.5.0-alpha.3`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.14] - 2026-05-06
+
+Fourteenth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.14`** (tag **`v0.5.0-alpha.14`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Insignia card**: hardening de render en estilos configurables (sanitización de valores CSS antes de interpolarlos en `<style>`), con fallback seguro para patrones de inyección.
+- **Graph card** (`0.12.20`): más separación vertical entre cabecera (icono + nombre) y fila de valor/chips.
+
+---
+
 ## [0.5.0-alpha.13] - 2026-05-06
 
 Thirteenth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.13`** (tag **`v0.5.0-alpha.13`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.12] - 2026-05-06
+
+Twelfth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.12`** (tag **`v0.5.0-alpha.12`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Graph card** (`0.12.20`): **hook/hover marker** alineado al recorrido de la línea (la capa de puntos usa el mismo viewport útil del SVG que el chart, sin desfase vertical por padding del panel).
+- **Graph card** (`0.12.20`): popup del hook con estilo más **semitransparente/glass** al estilo weather card (fondo refinado, borde más suave, doble sombra ligera e inner highlight).
+
+---
+
 ## [0.5.0-alpha.11] - 2026-05-06
 
 Eleventh **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.11`** (tag **`v0.5.0-alpha.11`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.15] - 2026-05-06
+
+Fifteenth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.15`** (tag **`v0.5.0-alpha.15`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Performance** (**Graph card**): hover más fluido y estable — actualizaciones coalescidas por **`requestAnimationFrame`**, menos trabajo por evento de puntero y cierre más robusto del popup/hook al salir de la tarjeta.
+- **Security hardening**: helper común **`sanitizeActionUrl`** en utilidades compartidas y aplicado a sinks de URL en tarjetas interactivas; aperturas en pestaña nueva unificadas a **`noopener,noreferrer`**.
+- **Security hardening** (**Navigation bar**): eliminación de interpolación de estilos inline dinámicos en HTML de runtime; estilos aplicados por **`style.setProperty(...)`** para reducir superficie de inyección.
+- **Security hardening**: modo estricto opcional para acciones de servicio configurable por tarjeta (**`strict_service_actions`** + allowlists de dominios/servicios).
+- **Editor UI**: corrección definitiva de sufijos literales como **`$1`** en etiquetas normalizadas (p. ej. **Mínimo/Máximo**).
+
+---
+
 ## [0.5.0-alpha.14] - 2026-05-06
 
 Fourteenth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.14`** (tag **`v0.5.0-alpha.14`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.6] - 2026-05-05
+
+Sixth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.6`** (tag **`v0.5.0-alpha.6`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Graph card** (`0.12.18`): **Tooltip** — no evaluar **`hover.x`** cuando no hay hover (**`null`**), evitando **`null is not an object (evaluating 'hover.x')`** en la tarjeta.
+- **Insignia card** (`0.2.6`): modo **solo icono** — corrección fina en fila con otras insignias: **`transform: translateY`** en **`:host([data-icon-only])`** con variable **`--insignia-icon-only-row-nudge`** (por defecto **`-2px`**).
+
+---
+
 ## [0.5.0-alpha.5] - 2026-05-05
 
 Fifth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.5`** (tag **`v0.5.0-alpha.5`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.5] - 2026-05-05
+
+Fifth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.5`** (tag **`v0.5.0-alpha.5`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Graph card** (`0.12.17`): **Hover** alineado con la **línea** — posición X en overlay y **tooltip** usando el mismo rango que el **viewBox** (padding horizontal negativo: ya no se usa **`x / 100`**). **Marcadores** al vuelo con estética **Power Flow** (gradiente + sombra, **pulse** suave) en lugar de anillos anteriores.
+- **Insignia card** (`0.2.5`): modo **solo icono** — alineación en **franjas horizontales** con otras insignias: **`:host`** con **`align-self: stretch`**, **`display: flex`** y **`align-items: center`**; **recorte** en scroll con **`padding-block`** (variables **`--insignia-scroll-strip-padding-block`** / compat **`--insignia-scroll-strip-margin-block`**, por defecto **`4px`**); ajuste óptico **`--insignia-icon-optical-y`** y **`svg { display: block }`**.
+- **Internals** (**`nodalia-utils.js`**): **`copyDatasetExcept`** ignora también **`field`**; **`pickerCallbackState`** + listeners estables para **callbacks** actualizados en pickers reutilizados.
+
+---
+
 ## [0.5.0-alpha.4] - 2026-05-05
 
 Fourth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.4`** (tag **`v0.5.0-alpha.4`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **Power Flow** polish, **translations**, **Graph Card** tuning, **Insignia** and editors. Prerelease workflow and tagging: **CONTRIBUTING**.
 
-- **Internals**: shared **`nodalia-utils.js`** (**`window.NodaliaUtils`**) — **`deepEqual` / `stripEqualToDefaults`**, cheap **`hass`** signatures for editors (**entity count** / **filtered counts** + locale tag instead of sorting full entity lists), **`mountEntityPickerHost` / `mountIconPickerHost`** to avoid recreating **`ha-entity-picker`** / **`ha-icon-picker`** every render; **`resolveEditorColorValue`** caches computed CSS colors in **`nodalia-bubble-contrast.js`**. **`npm run bundle`** includes **`nodalia-utils.js`** after i18n/editor-ui (see **CONTRIBUTING**). Recommended install remains single **`nodalia-cards.js`**.
+---
+
+## [0.5.0-alpha.2] - 2026-05-05
+
+Second **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.2`** (tag **`v0.5.0-alpha.2`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Graph card** (`0.12.14`): **chips** de leyenda en la **misma fila** que el **valor** (a la **derecha**), evitando solaparse con el recuadro del chart; en **vista estrecha** la leyenda pasa a **línea inferior** a ancho completo.
+- **Insignia card** (`0.2.2`): modo **solo icono** — **`overflow: visible`** en el host y en la píldora, **`icon_only_offset_y`** por defecto **`0`** para quitar el recorte mínimo **abajo** del círculo.
+- **Internals**: shared **`nodalia-utils.js`** (**`window.NodaliaUtils`**) — **`deepEqual` / `stripEqualToDefaults`**, firmas ligeras de **`hass`** en editores (**conteo** / **filtrados** + idioma), **`mountEntityPickerHost` / `mountIconPickerHost`** para no recrear **`ha-entity-picker`** / **`ha-icon-picker`** en cada render; **`resolveEditorColorValue`** cachea colores CSS en **`nodalia-bubble-contrast.js`**. El bundle incluye **`nodalia-utils.js`** tras i18n/editor-ui (véase **CONTRIBUTING**). Instalación recomendada: un solo **`nodalia-cards.js`**.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.13] - 2026-05-06
+
+Thirteenth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.13`** (tag **`v0.5.0-alpha.13`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Graph card** (`0.12.20`): header reorganizado — burbuja de icono junto al título en la esquina superior izquierda (icono a la izquierda del nombre).
+- **Graph card** (`0.12.20`): hover sincronizado — línea discontinua, círculo y popup comparten mapeo X del **`viewBox`**, sin desfase lateral.
+- **Editor UI**: corrección de normalización en etiquetas en español — los reemplazos con grupos (por ejemplo **`mínimo`** / **`máximo`**) ya no muestran sufijos literales como **`$1`**.
+
+---
+
 ## [0.5.0-alpha.12] - 2026-05-06
 
 Twelfth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.12`** (tag **`v0.5.0-alpha.12`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.10] - 2026-05-06
+
+Tenth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.10`** (tag **`v0.5.0-alpha.10`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Internals** (**`nodalia-utils.js`**): **`editorStatesSignature`** vuelve a reflejar **todas** las entidades (**`id`**, **`friendly_name`**, **`icon`** por fila), delegando en **`editorFilteredStatesSignature`** — los editores que listan entidades se actualizan al cambiar etiquetas o iconos, no solo al variar el **conteo**.
+- **Insignia card** (`0.2.11`): modo **solo icono** — tamaño exterior alineado con la **píldora con nombre/valor** (**padding** vertical de **`styles.card`** + disco del icono); **`padding-block`** del host por defecto **`0`** (franjas con scroll: variables **`--insignia-scroll-strip-*`**).
+
+---
+
 ## [0.5.0-alpha.9] - 2026-05-05
 
 Ninth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.9`** (tag **`v0.5.0-alpha.9`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,50 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **Power Flow** polish, **translations**, **Graph Card** tuning, **Insignia** and editors. Prerelease workflow and tagging: **CONTRIBUTING**.
+Work toward **`0.6.x`** on **`alpha`** / **`beta`** and eventual **`main`**: additional polish, performance and feature work after the **`0.5.0`** stable release. Prerelease workflow and tagging: **CONTRIBUTING**.
+
+---
+
+## [0.5.0] - 2026-05-06
+
+First stable release on the **`0.5.x`** line (**branch `main`**). This version consolidates all validated work from the **`0.5.0-alpha.*`** cycle into a production-ready bundle aimed at smoother interaction, stronger hardening, better editor UX and broader translation coverage.
+
+### Security hardening
+
+- Added shared **`sanitizeActionUrl()`** and applied it across URL action sinks to block unsafe schemes and normalize relative/same-origin navigation.
+- Standardized new-tab actions to **`noopener,noreferrer`** to reduce tabnabbing/referrer leakage risks.
+- Hardened service actions with optional strict mode and allowlists (**domains/services**) to reduce accidental abuse in action configs.
+- Removed dynamic inline style string interpolation in critical runtime paths (notably Navigation Bar route/popup styles), applying safe runtime style properties instead.
+- Added render-boundary CSS sanitization for user-configurable styles in cards with dynamic style templates (including Insignia and Circular Gauge paths), with safe fallback behavior.
+
+### Performance and fluency
+
+- Improved Graph hover fluidity with **`requestAnimationFrame`** coalescing and reduced per-move work under heavy pointer movement.
+- Fixed Graph tooltip lifecycle for stable tracking while moving the pointer (without waiting for stationary hover), with robust leave/close behavior.
+- Reduced drag overhead in interactive controls by caching geometry during slider drags and minimizing repeated layout reads.
+- Smoothed Climate dial interaction by coalescing drag updates per frame.
+- Kept standalone embedding/bundle sync idempotent to avoid unnecessary rewrites and noisy rebuild diffs.
+
+### Stability and bug fixes
+
+- Fixed Graph hook alignment issues (marker/guide/popup sync over chart path and viewBox mapping).
+- Fixed Graph header layout so icon bubble and title align consistently in the top-left header row.
+- Added spacing and layout refinements in Graph value/chips area for better readability in compact and normal views.
+- Fixed tooltip edge cases where popups could remain visible after leaving the card.
+- Corrected Insignia icon-only sizing/height parity with normal mode and removed clipping/regression cases in strip/scroll layouts.
+- Improved async state consistency in Advance Vacuum map actions by preventing overlapping runs and reducing race conditions after awaited service calls.
+
+### Editor and i18n
+
+- Fixed Spanish editor normalization artifacts where labels like **`Mínimo$1`** / **`Máximo$1`** could appear.
+- Strengthened editor label normalization and replacement group handling in generated editor UI runtime.
+- Expanded editor/source strings and completed additional translation keys across supported locales.
+- Maintained bundled language set coverage for cards and visual editors (**es, en, de, fr, it, nl, pt, ru, el, zh, ro**), with graceful fallback behavior for partial trees.
+
+### Developer and tooling
+
+- Refined shared utility behavior for editor entity signatures so label/icon attribute changes trigger expected refreshes (not only entity count changes).
+- Kept standalone utility embedding centralized and automatically stripped during bundle build to avoid duplicated runtime code in `nodalia-cards.js`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-Work toward **`0.4.1`** patches and the next minor (**`0.5.x`**): **Power Flow** polish, **translations**, **Graph Card** lines/axes, **curated default styles**. Prerelease workflow (**`beta`** / **`alpha`**) and tagging: **CONTRIBUTING**.
+Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **Power Flow** polish, **translations**, **Graph Card** tuning, **Insignia** and editors. Prerelease workflow and tagging: **CONTRIBUTING**.
+
+- **Internals**: shared **`nodalia-utils.js`** (**`window.NodaliaUtils`**) — **`deepEqual` / `stripEqualToDefaults`**, cheap **`hass`** signatures for editors (**entity count** / **filtered counts** + locale tag instead of sorting full entity lists), **`mountEntityPickerHost` / `mountIconPickerHost`** to avoid recreating **`ha-entity-picker`** / **`ha-icon-picker`** every render; **`resolveEditorColorValue`** caches computed CSS colors in **`nodalia-bubble-contrast.js`**. **`npm run bundle`** includes **`nodalia-utils.js`** after i18n/editor-ui (see **CONTRIBUTING**). Recommended install remains single **`nodalia-cards.js`**.
+
+---
+
+## [0.5.0-alpha.1] - 2026-05-06
+
+First **`alpha`** on the **0.5.x** line (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.1`** (tag **`v0.5.0-alpha.1`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Graph card** (`0.12.13`): el **recuadro de la gráfica** gana protagonismo — **ancho completo** respecto al contenido de la tarjeta con **márgenes negativos** como el mapa en **advance vacuum**, esquinas del panel alineadas al **`border_radius`** de la tarjeta; **valor principal**, **título** y **chips** de series algo más compactos; **`DEFAULT_CONFIG.styles`** por defecto más bajo en tipografía para dar más aire al área del chart; altura mínima del panel revisada.
+- **Insignia card** (`0.2.1`): editor visual con **`icon_active`** / **`icon_inactive`** y mismo criterio de **estado activo** que **Entity card**; hint de ayuda opcional como en Entity.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.3] - 2026-05-05
+
+Third **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.3`** (tag **`v0.5.0-alpha.3`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Graph card** (`0.12.15`): más **margen superior** del **recuadro del chart** respecto a la fila **valor / chips**.
+- **Insignia card** (`0.2.3`): modo **solo icono** — **padding** interior **`3px`**, glifo algo más **pequeño** respecto al círculo (**`-12px`** en lugar de `-8px`) y **`overflow: visible`** en **`ha-icon`** para reducir el recorte visual.
+
+---
+
 ## [0.5.0-alpha.2] - 2026-05-05
 
 Second **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.2`** (tag **`v0.5.0-alpha.2`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Work toward **`0.5.x`** on **`alpha`** / **`beta`** and eventual **`main`**: **P
 
 ---
 
+## [0.5.0-alpha.16] - 2026-05-06
+
+Sixteenth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.16`** (tag **`v0.5.0-alpha.16`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.
+
+- **Security hardening** (**Circular Gauge**): sanitización de valores CSS configurables en el borde de render (`styles.card`, `styles.icon`, `styles.gauge`, tamaños/chips) con fallback seguro antes de interpolación en `<style>`/SVG.
+- **Stability** (**Advance Vacuum**): lock de concurrencia para acciones de mapa (`_mapActionInFlight`) y resolución de modo de sesión con estado refrescado tras `await` para evitar carreras en interacciones rápidas.
+- **Performance / fluidez**: cache de geometría en arrastre de sliders de **Media Player** (menos `getBoundingClientRect()` por `pointermove`) y coalescing por `requestAnimationFrame` en drag del dial de **Climate**.
+- **i18n / editor UI**: ampliadas claves base de traducción y ajuste del generador para preservar correctamente expansiones con grupos (`$1`) en la salida embebida.
+
+---
+
 ## [0.5.0-alpha.15] - 2026-05-06
 
 Fifteenth **`alpha`** on **`0.5.x`** (**branch `alpha`**). **Experimental:** installs match **`package.json`** / **`__NODALIA_BUNDLE__.pkgVersion`** **`0.5.0-alpha.15`** (tag **`v0.5.0-alpha.15`** optional). Breaking changes are allowed; prefer **`main`** **`0.4.0`** stable for production dashboards.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,13 @@ Community help is especially useful for languages other than Spanish and English
 - **`nodalia-i18n.js`**: each locale object is **deep-merged** over **`PACK.en`**, so partially translated packs still expose **every card namespace** (fan, alarm, weather, …). Override strings inside **`PACK.<code>`** as translations are completed.
 - **Visual editors**: **`scripts/gen-editor-ui.mjs`** builds **`nodalia-editor-ui.js`**. Add **`pt` / `ru` / `el` / `zh` / `ro`** next to **`de`** / **`fr`** in **`FULL_LOCALE_BY_EN`** (and **`editor-extra-locale-by-en.json`** when used) for full phrases; compact UI strings use the **`enTo*`** helpers. Then run **`node scripts/gen-editor-ui.mjs`** and **`npm run bundle`**.
 
+### Bundle vs standalone scripts
+
+- **`npm run bundle`** runs **`scripts/build-bundle.mjs`** and writes **`nodalia-cards.js`**. Module order in **`parts`** matters: **`nodalia-i18n.js`** → **`nodalia-editor-ui.js`** → **`nodalia-utils.js`** → **`nodalia-bubble-contrast.js`** → card files. After changing **`parts`**, or any bundled source, run **`npm run bundle`** again.
+- **`nodalia-utils.js`** attaches **`window.NodaliaUtils`** (shared config stripping, lightweight editor **`hass` signatures**, entity/icon picker mount helpers). It expects **`NodaliaI18n`** from **`nodalia-i18n.js`** for locale-aware signatures.
+- **Normal setup:** one Lovelace resource pointing at **`nodalia-cards.js`** (documented in **`README.md`**).
+- **Advanced / debugging:** if you register separate **`nodalia-*.js`** resources, load **`nodalia-utils.js`** after **`nodalia-i18n.js`** and **`nodalia-editor-ui.js`**, and before any card that calls **`window.NodaliaUtils`**.
+
 ---
 
 ## 🏷️ Releases: `main`, `beta`, and `alpha`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 ### Stable **`main`**, then **`beta`**, then ongoing **`alpha` → beta`**
 
-1. **`main` (stable)** — **`package.json`** e.g. **`0.4.0`**, **`CHANGELOG`** **`[0.4.0]`**, **`npm run bundle`**, tag **`v0.4.0`**, GitHub **Release**.
+1. **`main` (stable)** — **`package.json`** e.g. **`0.5.0`**, **`CHANGELOG`** **`[0.5.0]`**, **`npm run bundle`**, tag **`v0.5.0`**, GitHub **Release**.
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.12`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.13`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -162,7 +162,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.12`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.13`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.9`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.10`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -162,7 +162,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.9`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.10`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.10`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.11`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -162,7 +162,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.10`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.11`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.11`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.12`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -162,7 +162,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.11`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.12`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.6`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.7`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -161,7 +161,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.6`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.7`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.7`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.8`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -161,7 +161,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.7`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.8`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.13`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.14`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -162,7 +162,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.13`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.14`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, **`0.5.0-alpha.3`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, **`0.5.0-alpha.3`**, **`0.5.0-alpha.4`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -161,7 +161,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, **`0.5.0-alpha.3`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, **`0.5.0-alpha.3`**, **`0.5.0-alpha.4`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, **`0.5.0-alpha.3`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -161,7 +161,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, **`0.5.0-alpha.3`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,10 +121,11 @@ Community help is especially useful for languages other than Spanish and English
 
 ### Bundle vs standalone scripts
 
-- **`npm run bundle`** runs **`scripts/build-bundle.mjs`** and writes **`nodalia-cards.js`**. Module order in **`parts`** matters: **`nodalia-i18n.js`** → **`nodalia-editor-ui.js`** → **`nodalia-utils.js`** → **`nodalia-bubble-contrast.js`** → card files. After changing **`parts`**, or any bundled source, run **`npm run bundle`** again.
+- **`npm run bundle`** runs **`scripts/sync-standalone-embed.mjs`** then **`scripts/build-bundle.mjs`** and writes **`nodalia-cards.js`**. Module order in **`parts`** matters: **`nodalia-i18n.js`** → **`nodalia-editor-ui.js`** → **`nodalia-utils.js`** → **`nodalia-bubble-contrast.js`** → card files. After changing **`parts`**, or any bundled source, run **`npm run bundle`** again.
 - **`nodalia-utils.js`** attaches **`window.NodaliaUtils`** (shared config stripping, lightweight editor **`hass` signatures**, entity/icon picker mount helpers). It expects **`NodaliaI18n`** from **`nodalia-i18n.js`** for locale-aware signatures.
 - **Normal setup:** one Lovelace resource pointing at **`nodalia-cards.js`** (documented in **`README.md`**).
-- **Advanced / debugging:** if you register separate **`nodalia-*.js`** resources, load **`nodalia-utils.js`** after **`nodalia-i18n.js`** and **`nodalia-editor-ui.js`**, and before any card that calls **`window.NodaliaUtils`**.
+- **Standalone single-card JS:** each shipped **`nodalia-*-card.js`** / **`nodalia-navigation-bar.js`** / **`nodalia-media-player.js`** begins with an **inlined copy** of **`nodalia-utils.js`** between **`// <nodalia-standalone-utils>`** and **`// </nodalia-standalone-utils>`**, so **`window.NodaliaUtils`** exists when only that script is loaded. **`build-bundle.mjs`** **strips** that block so **`nodalia-cards.js`** does not duplicate utilities (they come from the **`nodalia-utils.js`** module in **`parts`**). After editing **`nodalia-utils.js`**, run **`npm run bundle`** (or **`node scripts/sync-standalone-embed.mjs`**) so standalone files stay in sync.
+- **Advanced / debugging:** you may still load **`nodalia-utils.js`** once before cards (after **`nodalia-i18n.js`** / **`nodalia-editor-ui.js`**); the utils **`init`** guard skips re-installing when the API is already complete.
 
 ---
 
@@ -136,7 +137,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.8`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.9`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -161,7 +162,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.8`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.9`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, **`0.5.0-alpha.3`**, **`0.5.0-alpha.4`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.5`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -161,7 +161,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, **`0.5.0-alpha.3`**, **`0.5.0-alpha.4`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.5`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.14`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.15`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -162,7 +162,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.14`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.15`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.5`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.6`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -161,7 +161,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.5`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.6`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Three channels keep risk and expectations clear:
 |--------|----------------|------------------|--------------|
 | **`main`** | Everyone | **`v0.4.0`**, **`v0.4.1`**, **`v0.5.0`** (semver **only** stable minors/patches) | **Recommended** for normal dashboards. Only merged when the maintainer is happy to endorse the build widely. |
 | **`beta`** | Testers, early adopters | **`0.5.0-beta.1`**, **`0.5.0-beta.2`**, … (tags **`v0.5.0-beta.1`**, …) | **Pretty usable**; features are exercised but not guaranteed frozen. Promoted from **`alpha`** when a slice of work is **polished enough** (merge or cherry-pick). |
-| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.15`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
+| **`alpha`** | Developers / brave testers | **`0.5.0-alpha.1`**, …, **`0.5.0-alpha.16`**, … (tags **`v0.5.0-alpha.1`**, … optional) | **High churn**. Frequent commits; **dashboards may break**. Breaking YAML or behaviour is allowed here. |
 
 **Promotion flow (typical):** experimental work lands on **`alpha`** → when a feature (or batch) is stable enough, it moves to **`beta`** → when the whole minor is ready, **`beta`** merges to **`main`** as **`v0.5.0`** (example). Avoid merging **`alpha` → `main`** directly if you want **`beta`** to stay the gate for “probably OK for testers”.
 
@@ -162,7 +162,7 @@ Or branch **`alpha`** from **`beta`** if **`beta`** already tracks **`0.5.0-beta
 
 2. **`beta` (first prerelease of the next minor)** — merge **`main`** into **`beta`**, bump to **`0.5.0-beta.1`**, **`CHANGELOG`** **`## [0.5.0-beta.1]`**, **`npm run bundle`**, tag **`v0.5.0-beta.1`**.
 
-3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.15`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
+3. **`alpha` (experimental)** — work and tag **`0.5.0-alpha.1`**, **`0.5.0-alpha.2`**, …, **`0.5.0-alpha.16`**, … as often as you like; merge **`alpha` → `beta`** when a feature is **ready for testers**, then bump **`beta`** (**`0.5.0-beta.2`**, **`beta.3`**, …).
 
 4. **Stable minor** — when **`beta`** is release-ready, merge **`beta` → `main`**, set **`0.5.0`**, tag **`v0.5.0`**.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.1-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.2-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.1`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.2`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.2-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.3-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.2`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.3`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.10-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.11-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.10`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.11`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.1-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -82,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** future **`beta`** / **`alpha`** builds target **`0.4.1`**, **`0.5.x`**, … ahead of **`main`**; stable **`0.4.0`** is **`package.json`** on **`main`** (tag **`v0.4.0`**). Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.1`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.12-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.13-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.12`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.13`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.11-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.12-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.11`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.12`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.4-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.5-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.4`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.5`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.13-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.14-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.13`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.14`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.9-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.10-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.9`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.10`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.5-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.6-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.5`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.6`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.15-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.16-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.15`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.16`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.7-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.8-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.7`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.8`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.6-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.7-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.6`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.7`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🎨 Nodalia Cards
 
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
-![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
+![Latest stable](https://img.shields.io/badge/latest%20stable-0.5.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
 ![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.16-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
@@ -81,9 +81,9 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 ## 🌍 Translations
 
-**Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
+**Stable (`main`) — 0.5.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.16`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.16`** (experimental; **may break** dashboards) led development for this stable line. Current stable on **`main`** is **`0.5.0`**. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.8-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.9-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.8`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.9`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.3-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.4-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.3`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.4`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
 ![Latest stable](https://img.shields.io/badge/latest%20stable-0.4.0-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
-![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.14-orange)
+![Alpha branch](https://img.shields.io/badge/alpha-0.5.0--alpha.15-orange)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![GitHub](https://img.shields.io/badge/hosted%20on-GitHub-black?logo=github)
@@ -83,7 +83,7 @@ Copy `nodalia-cards.js` into `config/www/` (or a subfolder) and add a resource u
 
 **Stable (`main`) — 0.4.0** includes **es, en, de, fr, it, nl** plus **pt, ru, el, zh** (simplified), and **ro** for the bundled cards and Lovelace visual editors (partial trees merge from English; coverage is still improving). Spot a wrong or awkward string? Open an issue with the **Translation correction** template — see **CONTRIBUTING**.
 
-**Prereleases:** **`alpha`** **`0.5.0-alpha.14`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
+**Prereleases:** **`alpha`** **`0.5.0-alpha.15`** (experimental; **may break** dashboards) leads **`0.5.x`** development ahead of **`main`**. Stable **`0.4.0`** remains **`package.json`** on **`main`** until the next stable merge. Branch workflow and tagging: **CONTRIBUTING**.
 
 ---
 

--- a/examples/graph-card.yaml
+++ b/examples/graph-card.yaml
@@ -1,16 +1,25 @@
 type: custom:nodalia-graph-card
-name: Humedad
+name: Temperatura
+icon: mdi:thermometer
 entities:
-  - entity: sensor.termostato_dormitorios_humedad
-    name: Dormitorio de Rocio
-    color: "#f29f05"
-  - entity: sensor.termostato_habitaciones_comunes_humedad
+  - entity: sensor.termostato_dormitorios_temperatura
+    name: Dormitorio de Rocío
+    color: "#ffaa00"
+  - entity: sensor.termostato_habitaciones_comunes_temperatura
     name: Pasillo
-    color: "#42a5f5"
+    color: "#ffc677"
+min: 15
+max: 25
+points: 100
 hours_to_show: 24
-points: 48
 show_fill: true
 show_legend: true
+styles:
+  card:
+    padding: 18px
+    gap: 20px
+  icon:
+    size: 20px
 grid_options:
   columns: 12
   rows: 4

--- a/nodalia-advance-vacuum-card.js
+++ b/nodalia-advance-vacuum-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-advance-vacuum-card";
 const EDITOR_TAG = "nodalia-advance-vacuum-card-editor";
 const CARD_VERSION = "0.13.3";

--- a/nodalia-advance-vacuum-card.js
+++ b/nodalia-advance-vacuum-card.js
@@ -1857,6 +1857,7 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
     this._lastRenderSignature = "";
     this._animateContentOnNextRender = true;
     this._entranceAnimationResetTimer = 0;
+    this._mapActionInFlight = false;
 
     this._onShadowClick = this._onShadowClick.bind(this);
     this._onShadowChange = this._onShadowChange.bind(this);
@@ -5393,6 +5394,11 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
   }
 
   async _runMapAction() {
+    if (this._mapActionInFlight) {
+      return;
+    }
+    this._mapActionInFlight = true;
+    try {
     const state = this._getVacuumState();
     const selectedPredefinedZones = this._getPredefinedZones()
       .filter(zone => this._selectedPredefinedZoneIds.includes(zone.id))
@@ -5476,7 +5482,8 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
           command: "app_zoned_clean",
           params: selectedZones,
         });
-        const activeCleaningSessionMode = this._isRoomCleaningSessionActive(state) ? "rooms" : "zone";
+        const latestState = this._getVacuumState();
+        const activeCleaningSessionMode = this._isRoomCleaningSessionActive(latestState) ? "rooms" : "zone";
         if (!this._restoreTransientZoneMode()) {
           this._selectedManualZoneIndex = -1;
           this._draftZone = null;
@@ -5515,6 +5522,9 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
     this._clearPersistedCleaningSession();
     await this._callVacuumService("start");
     this._triggerHaptic("selection");
+    } finally {
+      this._mapActionInFlight = false;
+    }
   }
 
   _runCustomMenuItem(item) {

--- a/nodalia-advance-vacuum-card.js
+++ b/nodalia-advance-vacuum-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };
@@ -5118,7 +5156,15 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
 
     if (action === "url") {
       const target = actionConfig.new_tab === true ? "_blank" : "_self";
-      window.open(actionConfig.url_path || actionConfig.url, target);
+      const safeUrl = window.NodaliaUtils?.sanitizeActionUrl(actionConfig.url_path || actionConfig.url, { allowRelative: true }) || "";
+      if (!safeUrl) {
+        return;
+      }
+      if (target === "_blank") {
+        window.open(safeUrl, "_blank", "noopener,noreferrer");
+      } else {
+        window.location.assign(safeUrl);
+      }
       return;
     }
 
@@ -5131,7 +5177,7 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
 
     if (["call_service", "call-service", "perform_action", "perform-action"].includes(action)) {
       const service = actionConfig.service || actionConfig.perform_action;
-      if (!service || !this._hass) {
+      if (!service || !this._hass || !this._isServiceAllowed(service)) {
         return;
       }
       const [domain, serviceName] = String(service).split(".");
@@ -5153,8 +5199,30 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
     });
   }
 
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
   _callNamedService(service, data = {}, target = null) {
-    if (!this._hass || !service) {
+    if (!this._hass || !service || !this._isServiceAllowed(service)) {
       return;
     }
 

--- a/nodalia-advance-vacuum-card.js
+++ b/nodalia-advance-vacuum-card.js
@@ -440,71 +440,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -7811,9 +7746,7 @@ class NodaliaAdvanceVacuumCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.keys(hass?.states || {})
-      .sort((left, right) => left.localeCompare(right, "es"))
-      .join("|");
+    return window.NodaliaUtils.editorStatesSignature(hass, this._config?.language);
   }
 
   _captureFocusState() {
@@ -7895,7 +7828,7 @@ class NodaliaAdvanceVacuumCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(deepClone(this._config), DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(deepClone(this._config), DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-alarm-panel-card.js
+++ b/nodalia-alarm-panel-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-alarm-panel-card";
 const EDITOR_TAG = "nodalia-alarm-panel-card-editor";
 const CARD_VERSION = "0.7.0";

--- a/nodalia-alarm-panel-card.js
+++ b/nodalia-alarm-panel-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-alarm-panel-card.js
+++ b/nodalia-alarm-panel-card.js
@@ -187,71 +187,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -1717,11 +1652,12 @@ class NodaliaAlarmPanelCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("alarm_control_panel.") || entityId.startsWith("input_text."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(
+      hass,
+      this._config?.language,
+      id =>
+        id.startsWith("alarm_control_panel.") || id.startsWith("input_text."),
+    );
   }
 
   _watchEditorControlTag(tagName) {
@@ -1871,7 +1807,7 @@ class NodaliaAlarmPanelCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-bubble-contrast.js
+++ b/nodalia-bubble-contrast.js
@@ -18,10 +18,15 @@
     return entityId.includes(".") ? entityId.split(".")[0] : "";
   }
 
+  const resolveEditorColorValueCache = new Map();
+
   function resolveEditorColorValue(value) {
     const rawValue = String(value ?? "").trim();
     if (!rawValue || typeof document === "undefined") {
       return "";
+    }
+    if (resolveEditorColorValueCache.has(rawValue)) {
+      return resolveEditorColorValueCache.get(rawValue);
     }
 
     const probe = document.createElement("span");
@@ -31,13 +36,16 @@
     probe.style.color = "";
     probe.style.color = rawValue;
     if (!probe.style.color) {
+      resolveEditorColorValueCache.set(rawValue, rawValue);
       return rawValue;
     }
 
     (document.body || document.documentElement).appendChild(probe);
     const resolved = getComputedStyle(probe).color;
     probe.remove();
-    return resolved || rawValue;
+    const result = resolved || rawValue;
+    resolveEditorColorValueCache.set(rawValue, result);
+    return result;
   }
 
   function rgbToHueDegrees(r, g, b) {

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -42255,7 +42255,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.16";
+const CARD_VERSION = "0.12.17";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -42571,6 +42571,18 @@ function parsePaddingEdges(value, fallback = 16) {
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
+}
+
+/** Map SVG chart X (same space as viewBox width 100, incl. negative pad) to overlay %. */
+function graphChartXToPercent(x, chart) {
+  if (!chart || typeof chart.xMin !== "number" || typeof chart.xMax !== "number") {
+    return 50;
+  }
+  const span = chart.xMax - chart.xMin;
+  if (!Number.isFinite(span) || span <= 0) {
+    return 50;
+  }
+  return ((x - chart.xMin) / span) * 100;
 }
 
 function escapeSelectorValue(value) {
@@ -43801,12 +43813,20 @@ class NodaliaGraphCard extends HTMLElement {
     // Reserve extra bottom headroom so min values and stroke/glow
     // never get clipped by the rounded chart container.
     const paddingBottom = 14;
+    const spanX = width - (paddingX * 2);
+    const xMin = paddingX;
+    const xMax = paddingX + spanX;
     const bounds = this._getGraphBounds(series);
     const range = Math.max(bounds.max - bounds.min, 1);
 
     return {
       width,
       height,
+      paddingX,
+      paddingTop,
+      paddingBottom,
+      xMin,
+      xMax,
       entries: series.map(entry => {
         if (!entry.samples.length) {
           return {
@@ -43818,7 +43838,7 @@ class NodaliaGraphCard extends HTMLElement {
         }
 
         const points = entry.samples.map((sample, index) => {
-          const x = paddingX + ((width - (paddingX * 2)) * index) / Math.max(entry.samples.length - 1, 1);
+          const x = paddingX + (spanX * index) / Math.max(entry.samples.length - 1, 1);
           const normalized = clamp((sample.value - bounds.min) / range, 0, 1);
           const y = paddingTop + ((height - paddingTop - paddingBottom) * (1 - normalized));
           return { x, y };
@@ -43900,9 +43920,8 @@ class NodaliaGraphCard extends HTMLElement {
       return;
     }
 
-    const chartWidth = Number(tooltip.dataset.chartWidth || 0);
-    const anchorX = Number(tooltip.dataset.anchorX || 0);
-    if (!Number.isFinite(chartWidth) || chartWidth <= 0) {
+    const anchorXPct = Number(tooltip.dataset.anchorXPct);
+    if (!Number.isFinite(anchorXPct)) {
       return;
     }
 
@@ -43931,7 +43950,7 @@ class NodaliaGraphCard extends HTMLElement {
       || (typeof window !== "undefined" ? window.innerHeight : 0)
       || 640;
     const chartRect = chartWrap.getBoundingClientRect();
-    const anchorPx = clamp((anchorX / chartWidth) * chartRect.width, 0, chartRect.width);
+    const anchorPx = clamp((anchorXPct / 100) * chartRect.width, 0, chartRect.width);
     const anchorViewportX = chartRect.left + anchorPx;
     const anchorViewportY = chartRect.top + Math.max(22, chartRect.height * 0.28);
     const maxTooltipWidth = Math.min(260, viewportWidth - 24);
@@ -44061,13 +44080,13 @@ class NodaliaGraphCard extends HTMLElement {
     const animations = this._getAnimationSettings();
     const shouldAnimateEntrance = animations.enabled && this._animateContentOnNextRender;
     const shouldAnimateChart = animations.enabled && (shouldAnimateEntrance || this._animateChartOnNextRender);
+    const anchorXPct = graphChartXToPercent(hover.x, chart);
     const tooltipMarkup = hover
       ? `
         <div
           class="graph-card__tooltip ${this._hoverEntering && animations.enabled ? "graph-card__tooltip--entering" : ""}"
-          data-anchor-x="${hover.x.toFixed(2)}"
-          data-chart-width="${chart.width}"
-          style="left:${((hover.x / chart.width) * 100).toFixed(2)}%; --tooltip-tint:${escapeHtml(tooltipTint)};"
+          data-anchor-x-pct="${anchorXPct.toFixed(4)}"
+          style="left:${anchorXPct.toFixed(3)}%; --tooltip-tint:${escapeHtml(tooltipTint)};"
         >
           <div class="graph-card__tooltip-time">${escapeHtml(hover.label)}</div>
           <div class="graph-card__tooltip-values">
@@ -44379,47 +44398,34 @@ class NodaliaGraphCard extends HTMLElement {
         .graph-card__hover-point {
           align-items: center;
           display: inline-flex;
-          height: 12px;
+          height: 14px;
           justify-content: center;
           left: 0;
           pointer-events: none;
           position: absolute;
           top: 0;
           transform: translate(-50%, -50%);
-          width: 12px;
+          width: 14px;
           z-index: 3;
         }
 
-        .graph-card__hover-point-halo {
-          background: radial-gradient(circle, color-mix(in srgb, var(--hover-color) 24%, transparent) 0 42%, transparent 72%);
-          border-radius: 999px;
-          inset: -8px;
-          opacity: 0.9;
-          position: absolute;
-        }
-
-        .graph-card__hover-point-outer {
-          background:
-            linear-gradient(180deg, color-mix(in srgb, var(--hover-color) 32%, rgba(255,255,255,0.76)), color-mix(in srgb, var(--ha-card-background, #1f1f24) 72%, var(--hover-color)));
-          border: 1px solid color-mix(in srgb, var(--hover-color) 52%, rgba(255, 255, 255, 0.34));
+        .graph-card__hover-dot {
+          background: radial-gradient(
+            circle at 35% 35%,
+            rgba(255, 255, 255, 0.98) 0 35%,
+            color-mix(in srgb, var(--dot-color) 44%, rgba(255, 255, 255, 0.92)) 36% 100%
+          );
           border-radius: 999px;
           box-shadow:
-            0 8px 18px rgba(0, 0, 0, 0.18),
-            inset 0 1px 0 rgba(255, 255, 255, 0.3);
-          inset: 0;
-          position: absolute;
-        }
-
-        .graph-card__hover-point-ring {
-          background: color-mix(in srgb, var(--hover-color) 82%, rgba(255, 255, 255, 0.86));
-          border-radius: 999px;
-          box-shadow: 0 0 10px color-mix(in srgb, var(--hover-color) 34%, transparent);
-          height: 4.5px;
-          left: 50%;
-          position: absolute;
-          top: 50%;
-          transform: translate(-50%, -50%);
-          width: 4.5px;
+            0 0 0 3px color-mix(in srgb, var(--dot-color) 14%, transparent),
+            0 0 10px color-mix(in srgb, var(--dot-color) 20%, transparent);
+          display: block;
+          flex-shrink: 0;
+          height: 8px;
+          width: 8px;
+          animation: graph-card-hover-dot-pulse calc(var(--graph-card-hover-duration, 180ms) * 2.35) ease-in-out infinite alternate;
+          transform-origin: center;
+          will-change: transform;
         }
 
         .graph-card__tooltip {
@@ -44662,6 +44668,17 @@ class NodaliaGraphCard extends HTMLElement {
           }
         }
 
+        @keyframes graph-card-hover-dot-pulse {
+          0% {
+            opacity: 1;
+            transform: scale(1);
+          }
+          100% {
+            opacity: 0.94;
+            transform: scale(1.14);
+          }
+        }
+
         @keyframes graph-card-hover-line-in {
           0% { opacity: 0; }
           100% { opacity: 1; }
@@ -44678,6 +44695,7 @@ class NodaliaGraphCard extends HTMLElement {
         .graph-card__tooltip,
         .graph-card__hover-line,
         .graph-card__hover-point,
+        .graph-card__hover-dot,
         .graph-card__content,
         .graph-card__header,
         .graph-card__primary-row,
@@ -44829,13 +44847,11 @@ class NodaliaGraphCard extends HTMLElement {
                       if (!point) {
                         return "";
                       }
-                      const left = clamp((point.x / chart.width) * 100, 1.8, 98.2);
-                      const top = clamp((point.y / chart.height) * 100, 4, 96);
+                      const left = clamp(graphChartXToPercent(point.x, chart), 0.3, 99.7);
+                      const top = clamp((point.y / chart.height) * 100, 0.3, 99.7);
                       return `
-                        <span class="graph-card__hover-point" style="left:${left}%; top:${top}%; --hover-color:${escapeHtml(entry.color)};">
-                          <span class="graph-card__hover-point-halo"></span>
-                          <span class="graph-card__hover-point-outer"></span>
-                          <span class="graph-card__hover-point-ring"></span>
+                        <span class="graph-card__hover-point" style="left:${left}%; top:${top}%; --dot-color:${escapeHtml(entry.color)};">
+                          <span class="graph-card__hover-dot"></span>
                         </span>
                       `;
                     }).join("")}
@@ -72655,7 +72671,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.4";
+const CARD_VERSION = "0.2.5";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -73539,10 +73555,18 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         :host([data-icon-only]) {
+          align-self: stretch;
+          box-sizing: border-box;
+          display: flex;
+          align-items: center;
           justify-content: center;
           overflow: visible;
           width: auto;
-          margin-block: var(--insignia-scroll-strip-margin-block, 8px);
+          min-height: min-content;
+          padding-block: var(
+            --insignia-scroll-strip-padding-block,
+            var(--insignia-scroll-strip-margin-block, 4px)
+          );
         }
 
         * {
@@ -73688,7 +73712,11 @@ class NodaliaInsigniaCard extends HTMLElement {
           overflow: visible;
           position: relative;
           top: var(--icon-only-offset-y);
-          transform: translateY(0) !important;
+          transform: translateY(var(--insignia-icon-optical-y, -1px)) !important;
+        }
+
+        .insignia-card--icon-only .insignia-card__icon ha-icon svg {
+          display: block;
         }
 
         .insignia-card__copy {
@@ -85138,4 +85166,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.4","contentSha256_12":"47e42f5501e5"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.5","contentSha256_12":"8b6e4788a7ca"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -14588,6 +14588,9 @@
       });
     });
 
+    // Clean up legacy literal replacement artifacts left by earlier generator versions.
+    out = out.replace(/$(d+)/g, "");
+
     return out;
   }
 
@@ -14632,6 +14635,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -14755,6 +14759,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -14961,6 +15001,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };
@@ -16380,12 +16421,100 @@ class NodaliaNavigationBarCard extends HTMLElement {
       return;
     }
 
+    if (!this._isServiceAllowed(action.service)) {
+      return;
+    }
+
     const [domain, service] = String(action.service).split(".");
     if (!domain || !service) {
       return;
     }
 
     this._hass.callService(domain, service, action.service_data || {}, action.target);
+  }
+
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
+  _applyRouteRuntimeStyles(visibleRoutes, playDockEntrance) {
+    if (!this.shadowRoot) {
+      return;
+    }
+    visibleRoutes.forEach((route, index) => {
+      const node = this.shadowRoot.querySelector(`.nav-item[data-route-index="${index}"]`);
+      if (!(node instanceof HTMLElement)) {
+        return;
+      }
+      if (playDockEntrance) {
+        node.style.setProperty("--nav-enter-delay", `${Math.min(index * 38, 520)}ms`);
+      }
+      if (route.background) node.style.setProperty("--route-background", route.background);
+      if (route.color) node.style.setProperty("--route-color", route.color);
+      if (route.active_color) node.style.setProperty("--route-active-color", route.active_color);
+      if (route.active_background) node.style.setProperty("--route-active-background", route.active_background);
+      const badge = this._getBadge(route);
+      const badgeNode = node.querySelector(".nav-badge");
+      if (badgeNode instanceof HTMLElement) {
+        if (badge.background) badgeNode.style.setProperty("--badge-background", badge.background);
+        if (badge.color) badgeNode.style.setProperty("--badge-color", badge.color);
+      }
+    });
+  }
+
+  _applyPopupRuntimeStyles() {
+    if (!this.shadowRoot || !this._popupState?.route) {
+      return;
+    }
+    const panel = this.shadowRoot.querySelector(".popup-panel");
+    if (panel instanceof HTMLElement) {
+      const popupItems = this._getPopupItems(this._popupState.route);
+      const popupHasText = popupItems.some(item => Boolean(this._getRouteLabel(item) || item.description));
+      const isCompactPopup = !popupHasText && Number(this._popupState.columns || 1) === 1;
+      panel.style.left = this._popupState.left;
+      panel.style.top = this._popupState.top;
+      panel.style.width = isCompactPopup ? "fit-content" : this._popupState.width;
+      panel.style.setProperty("--popup-columns", String(this._popupState.columns || 1));
+      panel.style.setProperty(
+        "--popup-item-min",
+        this._popupState.itemMinWidth || `calc(${this._config.styles.popup.item_size} + 24px)`,
+      );
+    }
+    const popupItems = this._getPopupItems(this._popupState.route);
+    popupItems.forEach((item, popupIndex) => {
+      const node = this.shadowRoot.querySelector(`.popup-item[data-popup-item-index="${popupIndex}"]`);
+      if (!(node instanceof HTMLElement)) {
+        return;
+      }
+      if (item.background) node.style.setProperty("--popup-route-background", item.background);
+      if (item.color) node.style.setProperty("--popup-route-color", item.color);
+      if (item.active_color) node.style.setProperty("--popup-route-active-color", item.active_color);
+      if (item.active_background) node.style.setProperty("--popup-route-active-background", item.active_background);
+      const badge = this._getBadge(item);
+      const badgeNode = node.querySelector(".nav-badge");
+      if (badgeNode instanceof HTMLElement) {
+        if (badge.background) badgeNode.style.setProperty("--badge-background", badge.background);
+        if (badge.color) badgeNode.style.setProperty("--badge-color", badge.color);
+      }
+    });
   }
 
   _closePopup(shouldRender = true) {
@@ -17362,13 +17491,13 @@ class NodaliaNavigationBarCard extends HTMLElement {
         this._openPopup(route, options.anchorElement);
         return;
       case "url": {
-        const url = action.url_path || action.url || route.url || route.path;
+        const url = window.NodaliaUtils?.sanitizeActionUrl(action.url_path || action.url || route.url || route.path, { allowRelative: true }) || "";
         if (!url) {
           return;
         }
 
         if (action.new_tab) {
-          window.open(url, "_blank", "noopener");
+          window.open(url, "_blank", "noopener,noreferrer");
         } else {
           window.location.assign(url);
         }
@@ -17432,22 +17561,12 @@ class NodaliaNavigationBarCard extends HTMLElement {
         const hasDescription = Boolean(item.description);
         const isIconOnly = !hasLabel && !hasDescription;
         const ariaLabel = label || item.description || item.path || `Popup ${popupIndex + 1}`;
-        const itemStyle = [
-          item.background ? `--popup-route-background:${item.background};` : "",
-          item.color ? `--popup-route-color:${item.color};` : "",
-          item.active_color ? `--popup-route-active-color:${item.active_color};` : "",
-          item.active_background ? `--popup-route-active-background:${item.active_background};` : "",
-        ]
-          .filter(Boolean)
-          .join("");
-
         return `
           <button
             class="popup-item ${isActive ? "active" : ""} ${isIconOnly ? "icon-only" : ""}"
             type="button"
             data-popup-route-index="${this._popupState.routeIndex}"
             data-popup-item-index="${popupIndex}"
-            style="${itemStyle}"
             aria-label="${escapeHtml(ariaLabel)}"
           >
             <span class="popup-item__icon-wrap">
@@ -17456,7 +17575,6 @@ class NodaliaNavigationBarCard extends HTMLElement {
                 badge
                   ? `<span
                       class="nav-badge"
-                      style="--badge-background:${badge.background};--badge-color:${badge.color};"
                     >${escapeHtml(badge.content)}</span>`
                   : ""
               }
@@ -17488,7 +17606,6 @@ class NodaliaNavigationBarCard extends HTMLElement {
       <div class="popup-backdrop" data-popup-close="true"></div>
       <div
         class="popup-panel popup-panel--${this._popupState.direction} popup-panel--layout-${this._popupState.layout || "auto"} ${popupHasText ? "popup-panel--with-text" : "popup-panel--icon-only"} ${isCompactPopup ? "popup-panel--compact" : ""}"
-        style="left:${this._popupState.left};top:${this._popupState.top};width:${isCompactPopup ? "fit-content" : this._popupState.width};--popup-columns:${this._popupState.columns || 1};--popup-item-min:${this._popupState.itemMinWidth || `calc(${this._config.styles.popup.item_size} + 24px)`};"
       >
         <div class="popup-items">
           ${popupMarkup}
@@ -17982,15 +18099,6 @@ class NodaliaNavigationBarCard extends HTMLElement {
               const isActive = this._isRouteActive(route, currentPath);
               const badge = this._getBadge(route);
               const label = this._getRouteLabel(route);
-              const routeStyle = [
-                playDockEntrance ? `--nav-enter-delay:${Math.min(index * 38, 520)}ms;` : "",
-                route.background ? `--route-background:${route.background};` : "",
-                route.color ? `--route-color:${route.color};` : "",
-                route.active_color ? `--route-active-color:${route.active_color};` : "",
-                route.active_background ? `--route-active-background:${route.active_background};` : "",
-              ]
-                .filter(Boolean)
-                .join("");
               const hasPopup = this._getPopupItems(route).length > 0;
 
               return `
@@ -17998,7 +18106,6 @@ class NodaliaNavigationBarCard extends HTMLElement {
                   class="nav-item ${isActive ? "active" : ""} ${hasPopup ? "has-popup" : ""}${playDockEntrance ? " nav-item--entering" : ""}"
                   data-route-index="${index}"
                   type="button"
-                  style="${routeStyle}"
                   aria-label="${escapeHtml(label || route.path || `Route ${index + 1}`)}"
                 >
                   <span class="nav-icon-wrap">
@@ -18007,7 +18114,6 @@ class NodaliaNavigationBarCard extends HTMLElement {
                       badge
                         ? `<span
                             class="nav-badge"
-                            style="--badge-background:${badge.background};--badge-color:${badge.color};"
                           >${escapeHtml(badge.content)}</span>`
                         : ""
                     }
@@ -19294,6 +19400,9 @@ class NodaliaNavigationBarCard extends HTMLElement {
       ${popupMarkup}
       ${mediaBrowserMarkup}
     `;
+
+    this._applyRouteRuntimeStyles(visibleRoutes, playDockEntrance);
+    this._applyPopupRuntimeStyles();
 
     if (this._popupState) {
       this._schedulePopupPositionSync();
@@ -22704,6 +22813,10 @@ class NodaliaMediaPlayer extends HTMLElement {
       return;
     }
 
+    if (!this._isServiceAllowed(action.service)) {
+      return;
+    }
+
     const [domain, service] = String(action.service).split(".");
     if (!domain || !service) {
       return;
@@ -22727,6 +22840,28 @@ class NodaliaMediaPlayer extends HTMLElement {
     this._hass.callService(domain, service, payload);
   }
 
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
   _runActionDefinition(action, fallbackEntityId = "") {
     if (!action || action.action === "none") {
       return;
@@ -22747,13 +22882,13 @@ class NodaliaMediaPlayer extends HTMLElement {
         }
         break;
       case "url": {
-        const url = action.url_path || action.url;
+        const url = window.NodaliaUtils?.sanitizeActionUrl(action.url_path || action.url, { allowRelative: true }) || "";
         if (!url) {
           return;
         }
 
         if (action.new_tab) {
-          window.open(url, "_blank", "noopener");
+          window.open(url, "_blank", "noopener,noreferrer");
         } else {
           window.location.assign(url);
         }
@@ -42894,6 +43029,7 @@ class NodaliaGraphCard extends HTMLElement {
     this._onShadowClick = this._onShadowClick.bind(this);
     this._onShadowPointerMove = this._onShadowPointerMove.bind(this);
     this._onShadowPointerLeave = this._onShadowPointerLeave.bind(this);
+    this._onHoverMediaChange = this._onHoverMediaChange.bind(this);
     this._onShadowTouchStart = this._onShadowTouchStart.bind(this);
     this._onShadowTouchMove = this._onShadowTouchMove.bind(this);
     this._onShadowTouchEnd = this._onShadowTouchEnd.bind(this);
@@ -42905,6 +43041,17 @@ class NodaliaGraphCard extends HTMLElement {
     this.shadowRoot.addEventListener("touchmove", this._onShadowTouchMove, { passive: false });
     this.shadowRoot.addEventListener("touchend", this._onShadowTouchEnd);
     this.shadowRoot.addEventListener("touchcancel", this._onShadowTouchCancel);
+    // Defensive close: in some pointer transitions the shadow-root leave may be skipped.
+    this.addEventListener("pointerleave", this._onShadowPointerLeave);
+    this.addEventListener("mouseleave", this._onShadowPointerLeave);
+    this._hoverMediaQuery =
+      typeof window !== "undefined" && typeof window.matchMedia === "function"
+        ? window.matchMedia("(hover: hover)")
+        : null;
+    this._hoverSupported = this._hoverMediaQuery ? this._hoverMediaQuery.matches : true;
+    if (this._hoverMediaQuery && typeof this._hoverMediaQuery.addEventListener === "function") {
+      this._hoverMediaQuery.addEventListener("change", this._onHoverMediaChange);
+    }
   }
 
   disconnectedCallback() {
@@ -42919,9 +43066,19 @@ class NodaliaGraphCard extends HTMLElement {
       this._tooltipSyncFrame = 0;
     }
     this._pendingHoverIndex = null;
+    if (this._hoverMediaQuery && typeof this._hoverMediaQuery.removeEventListener === "function") {
+      this._hoverMediaQuery.removeEventListener("change", this._onHoverMediaChange);
+    }
     this._clearTouchPressTimer();
     this._touchPressState = null;
     this._touchHoverActive = false;
+  }
+
+  _onHoverMediaChange(event) {
+    this._hoverSupported = Boolean(event?.matches);
+    if (!this._hoverSupported) {
+      this._scheduleHoverRender(null);
+    }
   }
 
   connectedCallback() {
@@ -43258,7 +43415,7 @@ class NodaliaGraphCard extends HTMLElement {
   _onShadowPointerMove(event) {
     if (
       (typeof event.pointerType === "string" && event.pointerType === "touch")
-      || (typeof window !== "undefined" && typeof window.matchMedia === "function" && !window.matchMedia("(hover: hover)").matches)
+      || this._hoverSupported === false
     ) {
       return;
     }
@@ -43404,19 +43561,26 @@ class NodaliaGraphCard extends HTMLElement {
   }
 
   _scheduleHoverRender(nextIndex) {
-    if (nextIndex === this._hoverIndex) {
+    if (nextIndex === this._hoverIndex && this._pendingHoverIndex === null) {
       return;
     }
 
+    this._pendingHoverIndex = nextIndex;
     if (this._hoverFrame) {
-      window.cancelAnimationFrame(this._hoverFrame);
-      this._hoverFrame = 0;
+      return;
     }
 
-    this._pendingHoverIndex = null;
-    this._hoverEntering = nextIndex !== null && this._hoverIndex === null;
-    this._hoverIndex = nextIndex;
-    this._render();
+    this._hoverFrame = window.requestAnimationFrame(() => {
+      this._hoverFrame = 0;
+      const resolvedIndex = this._pendingHoverIndex;
+      this._pendingHoverIndex = null;
+      if (resolvedIndex === this._hoverIndex) {
+        return;
+      }
+      this._hoverEntering = resolvedIndex !== null && this._hoverIndex === null;
+      this._hoverIndex = resolvedIndex;
+      this._render();
+    });
   }
 
   _getHistoryRequestKey() {
@@ -62943,7 +63107,15 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
 
     if (action === "url") {
       const target = actionConfig.new_tab === true ? "_blank" : "_self";
-      window.open(actionConfig.url_path || actionConfig.url, target);
+      const safeUrl = window.NodaliaUtils?.sanitizeActionUrl(actionConfig.url_path || actionConfig.url, { allowRelative: true }) || "";
+      if (!safeUrl) {
+        return;
+      }
+      if (target === "_blank") {
+        window.open(safeUrl, "_blank", "noopener,noreferrer");
+      } else {
+        window.location.assign(safeUrl);
+      }
       return;
     }
 
@@ -62956,7 +63128,7 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
 
     if (["call_service", "call-service", "perform_action", "perform-action"].includes(action)) {
       const service = actionConfig.service || actionConfig.perform_action;
-      if (!service || !this._hass) {
+      if (!service || !this._hass || !this._isServiceAllowed(service)) {
         return;
       }
       const [domain, serviceName] = String(service).split(".");
@@ -62978,8 +63150,30 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
     });
   }
 
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
   _callNamedService(service, data = {}, target = null) {
-    if (!this._hass || !service) {
+    if (!this._hass || !service || !this._isServiceAllowed(service)) {
       return;
     }
 
@@ -67698,8 +67892,34 @@ class NodaliaEntityCard extends HTMLElement {
     }
   }
 
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
   _callConfiguredService(serviceValue, entityId = this._config?.entity, rawData = "") {
     if (!this._hass || !serviceValue) {
+      return;
+    }
+
+    if (!this._isServiceAllowed(serviceValue)) {
       return;
     }
 
@@ -67717,7 +67937,7 @@ class NodaliaEntityCard extends HTMLElement {
   }
 
   _openConfiguredUrl(urlValue = this._config?.tap_url, newTab = this._config?.tap_new_tab === true) {
-    const url = String(urlValue || "").trim();
+    const url = window.NodaliaUtils?.sanitizeActionUrl(urlValue, { allowRelative: true }) || "";
     if (!url) {
       return;
     }
@@ -70978,8 +71198,34 @@ class NodaliaFavCard extends HTMLElement {
     }
   }
 
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
   _callConfiguredService(serviceValue, entityId = this._config?.entity, rawData = "") {
     if (!this._hass || !serviceValue) {
+      return;
+    }
+
+    if (!this._isServiceAllowed(serviceValue)) {
       return;
     }
 
@@ -70997,7 +71243,7 @@ class NodaliaFavCard extends HTMLElement {
   }
 
   _openConfiguredUrl(urlValue = this._config?.tap_url, newTab = this._config?.tap_new_tab === true) {
-    const url = String(urlValue || "").trim();
+    const url = window.NodaliaUtils?.sanitizeActionUrl(urlValue, { allowRelative: true }) || "";
     if (!url) {
       return;
     }
@@ -73490,6 +73736,28 @@ class NodaliaInsigniaCard extends HTMLElement {
     return "var(--info-color, #71c0ff)";
   }
 
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
   _onClick(event) {
     const trigger = event
       .composedPath()
@@ -73528,6 +73796,9 @@ class NodaliaInsigniaCard extends HTMLElement {
     }
 
     if (action === "service" && this._config.tap_service) {
+      if (!this._isServiceAllowed(this._config.tap_service)) {
+        return;
+      }
       const [domain, service] = this._config.tap_service.split(".");
       if (domain && service) {
         let serviceData = {};
@@ -73559,10 +73830,14 @@ class NodaliaInsigniaCard extends HTMLElement {
     }
 
     if (action === "url" && this._config.tap_url) {
+      const safeUrl = window.NodaliaUtils?.sanitizeActionUrl(this._config.tap_url, { allowRelative: true });
+      if (!safeUrl) {
+        return;
+      }
       if (this._config.tap_new_tab) {
-        window.open(this._config.tap_url, "_blank", "noopener");
+        window.open(safeUrl, "_blank", "noopener,noreferrer");
       } else {
-        window.location.href = this._config.tap_url;
+        window.location.href = safeUrl;
       }
     }
   }
@@ -85237,4 +85512,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.14","contentSha256_12":"a6514431c692"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.15","contentSha256_12":"92311cc34a35"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -14618,7 +14618,21 @@
  * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
  */
 (function initNodaliaUtils() {
-  if (typeof window !== "undefined" && window.NodaliaUtils?.stripEqualToDefaults && window.NodaliaUtils?.deepEqual) {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
     return;
   }
 
@@ -14713,21 +14727,31 @@
   }
 
   /**
-   * Count entities matching predicate(entityId); same locale prefix as editorStatesSignature.
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
    */
   function editorFilteredStatesSignature(hass, language, predicate) {
     const states = hass?.states || {};
-    let n = 0;
+    const rows = [];
     for (const id of Object.keys(states)) {
-      if (predicate(id)) {
-        n += 1;
+      if (!predicate(id)) {
+        continue;
       }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
     }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
     const tag =
       typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
         ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
         : "";
-    return `${tag}|${n}`;
+    return `${tag}|${rows.join("|")}`;
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -42255,7 +42279,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.17";
+const CARD_VERSION = "0.12.18";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -44080,7 +44104,7 @@ class NodaliaGraphCard extends HTMLElement {
     const animations = this._getAnimationSettings();
     const shouldAnimateEntrance = animations.enabled && this._animateContentOnNextRender;
     const shouldAnimateChart = animations.enabled && (shouldAnimateEntrance || this._animateChartOnNextRender);
-    const anchorXPct = graphChartXToPercent(hover.x, chart);
+    const anchorXPct = hover ? graphChartXToPercent(hover.x, chart) : 0;
     const tooltipMarkup = hover
       ? `
         <div
@@ -72671,7 +72695,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.5";
+const CARD_VERSION = "0.2.6";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -73563,6 +73587,7 @@ class NodaliaInsigniaCard extends HTMLElement {
           overflow: visible;
           width: auto;
           min-height: min-content;
+          transform: translateY(var(--insignia-icon-only-row-nudge, -2px));
           padding-block: var(
             --insignia-scroll-strip-padding-block,
             var(--insignia-scroll-strip-margin-block, 4px)
@@ -85166,4 +85191,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.5","contentSha256_12":"8b6e4788a7ca"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.6","contentSha256_12":"70136d5d2f52"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -44202,6 +44202,10 @@ class NodaliaGraphCard extends HTMLElement {
           min-width: 0;
         }
 
+        .graph-card__header + .graph-card__primary-row {
+          margin-top: 6px;
+        }
+
         .graph-card__primary-row .graph-card__value {
           flex: 0 1 auto;
           min-width: 0;
@@ -73068,6 +73072,48 @@ function escapeSelectorValue(value) {
   return String(value ?? "").replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
+function sanitizeCssValue(value, fallback) {
+  const raw = String(value ?? "").trim();
+  const safeFallback = String(fallback ?? "").trim();
+  if (!raw) {
+    return safeFallback;
+  }
+  if (/[\u0000-\u001f\u007f<>;"'{}]/.test(raw) || raw.includes("/*") || raw.includes("*/")) {
+    return safeFallback;
+  }
+  return raw;
+}
+
+function getSafeStyles(styles = DEFAULT_CONFIG.styles) {
+  const defaults = DEFAULT_CONFIG.styles;
+  const card = styles?.card || {};
+  const icon = styles?.icon || {};
+  const tint = styles?.tint || {};
+
+  return {
+    card: {
+      background: sanitizeCssValue(card.background, defaults.card.background),
+      border: sanitizeCssValue(card.border, defaults.card.border),
+      border_radius: sanitizeCssValue(card.border_radius, defaults.card.border_radius),
+      box_shadow: sanitizeCssValue(card.box_shadow, defaults.card.box_shadow),
+      gap: sanitizeCssValue(card.gap, defaults.card.gap),
+      padding: sanitizeCssValue(card.padding, defaults.card.padding),
+    },
+    icon: {
+      background: sanitizeCssValue(icon.background, defaults.icon.background),
+      icon_only_offset_y: sanitizeCssValue(icon.icon_only_offset_y, defaults.icon.icon_only_offset_y),
+      off_color: sanitizeCssValue(icon.off_color, defaults.icon.off_color),
+      on_color: sanitizeCssValue(icon.on_color, defaults.icon.on_color),
+      size: sanitizeCssValue(icon.size, defaults.icon.size),
+    },
+    tint: {
+      color: sanitizeCssValue(tint.color, defaults.tint.color),
+    },
+    title_size: sanitizeCssValue(styles?.title_size, defaults.title_size),
+    value_size: sanitizeCssValue(styles?.value_size, defaults.value_size),
+  };
+}
+
 function clampNumber(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
@@ -73405,7 +73451,7 @@ class NodaliaInsigniaCard extends HTMLElement {
 
   _getTintColor(state) {
     if (this._config?.tint_auto === false) {
-      return this._config?.styles?.tint?.color || DEFAULT_CONFIG.styles.tint.color;
+      return sanitizeCssValue(this._config?.styles?.tint?.color, DEFAULT_CONFIG.styles.tint.color);
     }
 
     const domain = getEntityDomain(state);
@@ -73536,7 +73582,7 @@ class NodaliaInsigniaCard extends HTMLElement {
     }
 
     const config = this._config || normalizeConfig({});
-    const styles = config.styles || DEFAULT_CONFIG.styles;
+    const styles = getSafeStyles(config.styles);
     const state = this._getState();
 
     if (!state && !config.name && !config.icon) {
@@ -73578,7 +73624,7 @@ class NodaliaInsigniaCard extends HTMLElement {
     const icon = this._getResolvedIcon(state);
     const active = this._isActive(state);
     const dimIcon = this._shouldDimIcon(state);
-    const tint = this._getTintColor(state);
+    const tint = sanitizeCssValue(this._getTintColor(state), DEFAULT_CONFIG.styles.tint.color);
     const strongTint = this._shouldApplyStrongCardTint(state);
     const cardBackground = strongTint
       ? `linear-gradient(135deg, color-mix(in srgb, ${tint} 18%, ${styles.card.background}) 0%, color-mix(in srgb, ${tint} 10%, ${styles.card.background}) 52%, ${styles.card.background} 100%)`
@@ -85191,4 +85237,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.13","contentSha256_12":"69f140fedf7f"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.14","contentSha256_12":"a6514431c692"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -43319,6 +43319,7 @@ class NodaliaGraphCard extends HTMLElement {
     this._animateChartOnNextRender = false;
     this._lastRenderSignature = "";
     this._tooltipSyncFrame = 0;
+    this._lastTooltipViewportPosition = null;
     this._touchPressTimer = 0;
     this._touchPressState = null;
     this._touchHoverActive = false;
@@ -43733,6 +43734,7 @@ class NodaliaGraphCard extends HTMLElement {
     }
 
     this._scheduleHoverRender(null);
+    this._lastTooltipViewportPosition = null;
   }
 
   _clearTouchPressTimer() {
@@ -43875,6 +43877,9 @@ class NodaliaGraphCard extends HTMLElement {
         return;
       }
       this._hoverEntering = resolvedIndex !== null && this._hoverIndex === null;
+      if (resolvedIndex === null) {
+        this._lastTooltipViewportPosition = null;
+      }
       this._hoverIndex = resolvedIndex;
       this._render();
     });
@@ -44472,6 +44477,11 @@ class NodaliaGraphCard extends HTMLElement {
       shouldShowBelow ? "translate(-50%, 0)" : "translate(-50%, -100%)",
     );
     tooltip.style.opacity = "1";
+    this._lastTooltipViewportPosition = {
+      left: resolvedCenter,
+      top: resolvedTop,
+      transform: shouldShowBelow ? "translate(-50%, 0)" : "translate(-50%, -100%)",
+    };
   }
 
   _getSeriesData() {
@@ -44571,12 +44581,15 @@ class NodaliaGraphCard extends HTMLElement {
     const shouldAnimateEntrance = animations.enabled && this._animateContentOnNextRender;
     const shouldAnimateChart = animations.enabled && (shouldAnimateEntrance || this._animateChartOnNextRender);
     const anchorXPct = hover ? graphChartXToPercent(hover.x, chart) : 0;
+    const initialTooltipStyle = this._lastTooltipViewportPosition
+      ? `left:${this._lastTooltipViewportPosition.left}px; top:${this._lastTooltipViewportPosition.top}px; opacity:1; --graph-tooltip-transform:${this._lastTooltipViewportPosition.transform}; --tooltip-tint:${escapeHtml(tooltipTint)};`
+      : `left:-9999px; top:-9999px; opacity:0; --tooltip-tint:${escapeHtml(tooltipTint)};`;
     const tooltipMarkup = hover
       ? `
         <div
           class="graph-card__tooltip ${this._hoverEntering && animations.enabled ? "graph-card__tooltip--entering" : ""}"
           data-anchor-x-pct="${anchorXPct.toFixed(4)}"
-          style="left:-9999px; top:-9999px; opacity:0; --tooltip-tint:${escapeHtml(tooltipTint)};"
+          style="${initialTooltipStyle}"
         >
           <div class="graph-card__tooltip-time">${escapeHtml(hover.label)}</div>
           <div class="graph-card__tooltip-values">
@@ -85849,4 +85862,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.16","contentSha256_12":"65441736f930"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0","contentSha256_12":"6c52559e0f8e"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -72702,7 +72702,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.11";
+const CARD_VERSION = "0.2.12";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -72891,29 +72891,6 @@ function deleteByPath(target, path) {
 function parseSizeToPixels(value, fallback = 0) {
   const numeric = Number.parseFloat(String(value ?? ""));
   return Number.isFinite(numeric) ? numeric : fallback;
-}
-
-/** Sum of top + bottom padding from CSS shorthand (px numbers). */
-function parsePaddingVertical(padding, fallback = 8) {
-  const raw = String(padding ?? "").trim();
-  if (!raw) {
-    return fallback;
-  }
-  const tokens = raw.split(/\s+/).filter(Boolean);
-  const px = tokens.map(token => parseSizeToPixels(token, Number.NaN)).filter(n => Number.isFinite(n));
-  if (!px.length) {
-    return fallback;
-  }
-  if (px.length === 1) {
-    return px[0] * 2;
-  }
-  if (px.length === 2) {
-    return px[0] * 2;
-  }
-  if (px.length === 3) {
-    return px[0] + px[2];
-  }
-  return px[0] + px[2];
 }
 
 function normalizeTextKey(value) {
@@ -73590,16 +73567,6 @@ class NodaliaInsigniaCard extends HTMLElement {
     const showName = config.show_name !== false;
     const showValue = config.show_value !== false && Boolean(value);
     const iconOnly = !showName && !showValue;
-    const cardPaddingVertical = parsePaddingVertical(
-      styles.card?.padding ?? DEFAULT_CONFIG.styles.card.padding,
-      8,
-    );
-    // Outer square matches pill height: vertical padding + icon disc (same as non–icon-only row).
-    const iconOnlySize = cardPaddingVertical + iconSizePx;
-    const iconOnlyContentInset = 6;
-    const iconOnlyInner = Math.max(0, iconOnlySize - iconOnlyContentInset);
-    const iconGlyphDefault = Math.round(iconSizePx * 0.5);
-    const iconOnlyIconSize = Math.max(16, Math.min(iconGlyphDefault, iconOnlyInner));
     const iconOnlyOffsetY = String(styles.icon?.icon_only_offset_y ?? DEFAULT_CONFIG.styles.icon.icon_only_offset_y);
     const pictureUrl = this._getResolvedPicture(state);
     const showPicture = Boolean(pictureUrl);
@@ -73627,10 +73594,9 @@ class NodaliaInsigniaCard extends HTMLElement {
           width: auto;
           min-height: min-content;
           transform: translateY(var(--insignia-icon-only-row-nudge, -2px));
-          /* Default 0 so icon-only height matches the text pill; use vars in horizontal scroll strips. */
           padding-block: var(
             --insignia-scroll-strip-padding-block,
-            var(--insignia-scroll-strip-margin-block, 0px)
+            var(--insignia-scroll-strip-margin-block, 4px)
           );
         }
 
@@ -73659,13 +73625,9 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         .insignia-card--icon-only {
           border-radius: ${styles.card.border_radius};
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          height: var(--icon-only-size);
-          min-height: var(--icon-only-size);
-          min-width: var(--icon-only-size);
-          width: var(--icon-only-size);
+          height: auto;
+          width: fit-content;
+          max-width: 100%;
         }
 
         .insignia-card::before {
@@ -73705,17 +73667,11 @@ class NodaliaInsigniaCard extends HTMLElement {
           z-index: 1;
         }
 
+        /* Solo icono: misma fila / padding / gap que la píldora con texto; sin segunda columna (no forzar cuadrado). */
         .insignia-card--icon-only .insignia-card__content {
-          align-items: center;
-          border-radius: inherit;
-          box-sizing: border-box;
-          display: grid;
-          place-items: center;
-          margin: 0;
-          padding: 3px;
-          grid-template-columns: 1fr;
-          width: 100%;
-          height: 100%;
+          grid-template-columns: min(${iconSizePx}px, 100%);
+          width: fit-content;
+          max-width: 100%;
         }
 
         .insignia-card__icon {
@@ -73736,25 +73692,6 @@ class NodaliaInsigniaCard extends HTMLElement {
           width: ${iconSizePx}px;
         }
 
-        .insignia-card--icon-only .insignia-card__icon {
-          align-self: center;
-          border-radius: inherit;
-          justify-self: center;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          line-height: 0;
-          height: 100%;
-          margin: 0;
-          width: 100%;
-        }
-
-        .insignia-card--icon-only .insignia-card__icon {
-          background: transparent;
-          border: none;
-          box-shadow: none;
-        }
-
         .insignia-card__icon img {
           border-radius: inherit;
           height: 100%;
@@ -73769,21 +73706,10 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         .insignia-card--icon-only .insignia-card__icon ha-icon {
-          --mdc-icon-size: var(--icon-only-icon-size);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          height: var(--icon-only-icon-size);
-          width: var(--icon-only-icon-size);
-          line-height: 0;
           overflow: visible;
           position: relative;
           top: var(--icon-only-offset-y);
-          transform: translateY(var(--insignia-icon-optical-y, -1px)) !important;
-        }
-
-        .insignia-card--icon-only .insignia-card__icon ha-icon svg {
-          display: block;
+          transform: translateY(var(--insignia-icon-optical-y, -1px));
         }
 
         .insignia-card__copy {
@@ -73846,7 +73772,7 @@ class NodaliaInsigniaCard extends HTMLElement {
           width: 10px;
         }
       </style>
-      <div class="insignia-card ${iconOnly ? "insignia-card--icon-only" : ""}" style="--icon-only-size: ${iconOnlySize}px; --icon-only-icon-size: ${iconOnlyIconSize}px; --icon-only-offset-y: ${iconOnlyOffsetY}; ${isVisible ? "" : "display:none;"}">
+      <div class="insignia-card ${iconOnly ? "insignia-card--icon-only" : ""}" style="--icon-only-offset-y: ${iconOnlyOffsetY}; ${isVisible ? "" : "display:none;"}">
         <div class="insignia-card__content" data-insignia-action="primary">
           <div class="insignia-card__icon">
             ${showPicture
@@ -73855,11 +73781,15 @@ class NodaliaInsigniaCard extends HTMLElement {
             }
             ${unavailable ? '<span class="insignia-card__unavailable-badge"><ha-icon icon="mdi:help"></ha-icon></span>' : ""}
           </div>
+          ${iconOnly
+            ? ""
+            : `
           <div class="insignia-card__copy">
             ${showName ? `<div class="insignia-card__title">${escapeHtml(title)}</div>` : ""}
             ${showName && showValue ? '<span class="insignia-card__dot"></span>' : ""}
             ${showValue ? `<div class="insignia-card__value">${escapeHtml(value)}</div>` : ""}
           </div>
+          `}
         </div>
       </div>
     `;
@@ -85233,4 +85163,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.10","contentSha256_12":"e559c97721fd"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.11","contentSha256_12":"294512605e1c"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -14740,6 +14740,30 @@
     });
   }
 
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
   /**
    * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
    */
@@ -14790,7 +14814,7 @@
 
       control.dataset.field = field;
       if (copyDatasetFromHost) {
-        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder"]);
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
       }
 
       if ("hass" in control) {
@@ -14803,10 +14827,14 @@
         control.placeholder = placeholder;
       }
 
-      if (control.tagName === "INPUT") {
-        control.addEventListener("change", onShadowInput);
-      } else {
-        control.addEventListener("value-changed", onShadowValueChanged || onShadowInput);
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
       }
 
       host.appendChild(control);
@@ -14815,6 +14843,7 @@
 
     control.dataset.field = field;
     control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
     if ("hass" in control) {
       control.hass = hass;
     }
@@ -14859,7 +14888,7 @@
       }
 
       if (copyDatasetFromHost) {
-        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder"]);
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
       }
 
       if ("hass" in control) {
@@ -14872,16 +14901,21 @@
         control.value = nextValue;
       }
 
-      if (control.tagName === "INPUT") {
-        control.addEventListener("change", onShadowInput);
-      } else {
-        control.addEventListener("value-changed", onShadowValueChanged || onShadowInput);
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
       }
 
       host.appendChild(control);
       return;
     }
 
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
     if ("hass" in control) {
       control.hass = hass;
     }
@@ -42221,7 +42255,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.15";
+const CARD_VERSION = "0.12.16";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -42246,12 +42280,12 @@ const TOUCH_CLICK_SUPPRESSION_WINDOW = 350;
 const DEFAULT_CONFIG = {
   entity: "",
   entities: [],
-  name: "",
-  icon: "",
-  min: "",
-  max: "",
+  name: "Temperatura",
+  icon: "mdi:thermometer",
+  min: 15,
+  max: 25,
   hours_to_show: 24,
-  points: 480,
+  points: 100,
   show_header: true,
   show_icon: true,
   show_value: true,
@@ -42275,12 +42309,12 @@ const DEFAULT_CONFIG = {
       border: "1px solid var(--divider-color)",
       border_radius: "30px",
       box_shadow: "var(--ha-card-box-shadow)",
-      padding: "16px",
-      gap: "10px",
+      padding: "18px",
+      gap: "20px",
     },
     icon: {
       color: "var(--primary-text-color)",
-      size: "28px",
+      size: "20px",
     },
     title_size: "13px",
     value_size: "40px",
@@ -42292,17 +42326,20 @@ const DEFAULT_CONFIG = {
 };
 
 const STUB_CONFIG = {
-  name: "Humedad",
+  name: "Temperatura",
+  icon: "mdi:thermometer",
+  min: 15,
+  max: 25,
   entities: [
     {
-      entity: "sensor.termostato_dormitorios_humedad",
-      name: "Dormitorio de Rocio",
-      color: "#f29f05",
+      entity: "sensor.termostato_dormitorios_temperatura",
+      name: "Dormitorio de Rocío",
+      color: "#ffaa00",
     },
     {
-      entity: "sensor.termostato_habitaciones_comunes_humedad",
+      entity: "sensor.termostato_habitaciones_comunes_temperatura",
       name: "Pasillo",
-      color: "#42a5f5",
+      color: "#ffc677",
     },
   ],
 };
@@ -45287,7 +45324,7 @@ class NodaliaGraphCardEditorLegacy extends HTMLElement {
           </div>
           <div class="editor-grid">
             ${this._renderTextField("Nombre", "name", config.name, {
-              placeholder: "Humedad",
+              placeholder: "Temperatura",
             })}
             ${this._renderTextField("Icono", "icon", config.icon, {
               placeholder: "mdi:water-percent",
@@ -72618,7 +72655,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.3";
+const CARD_VERSION = "0.2.4";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -73428,6 +73465,7 @@ class NodaliaInsigniaCard extends HTMLElement {
     const state = this._getState();
 
     if (!state && !config.name && !config.icon) {
+      this.removeAttribute("data-icon-only");
       this.shadowRoot.innerHTML = `
         <style>
           :host { display: block; }
@@ -73504,6 +73542,7 @@ class NodaliaInsigniaCard extends HTMLElement {
           justify-content: center;
           overflow: visible;
           width: auto;
+          margin-block: var(--insignia-scroll-strip-margin-block, 8px);
         }
 
         * {
@@ -85099,4 +85138,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.3","contentSha256_12":"78f0762fc1b1"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.4","contentSha256_12":"47e42f5501e5"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -14578,7 +14578,14 @@
     ];
 
     substitutions.forEach(([pattern, replacement]) => {
-      out = out.replace(pattern, match => withMatchCase(match, replacement));
+      out = out.replace(pattern, (match, ...rest) => {
+        const groups = rest.slice(0, -2);
+        const expanded = String(replacement).replace(/$(d+)/g, (_, groupIndexRaw) => {
+          const groupIndex = Number(groupIndexRaw) - 1;
+          return groups[groupIndex] ?? "";
+        });
+        return withMatchCase(match, expanded);
+      });
     });
 
     return out;
@@ -42593,16 +42600,16 @@ function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
 
-/** Map SVG chart X (same space as viewBox width 100, incl. negative pad) to overlay %. */
+/** Map SVG viewBox X (0..chart.width) to overlay percentage. */
 function graphChartXToPercent(x, chart) {
-  if (!chart || typeof chart.xMin !== "number" || typeof chart.xMax !== "number") {
+  if (!chart || typeof chart.width !== "number") {
     return 50;
   }
-  const span = chart.xMax - chart.xMin;
-  if (!Number.isFinite(span) || span <= 0) {
+  const width = chart.width;
+  if (!Number.isFinite(width) || width <= 0) {
     return 50;
   }
-  return ((x - chart.xMin) / span) * 100;
+  return (x / width) * 100;
 }
 
 function escapeSelectorValue(value) {
@@ -44172,10 +44179,11 @@ class NodaliaGraphCard extends HTMLElement {
         }
 
         .graph-card__header {
-          align-items: start;
-          display: grid;
+          align-items: center;
+          display: flex;
           gap: 8px;
-          grid-template-columns: minmax(0, 1fr) auto;
+          justify-content: flex-start;
+          min-width: 0;
         }
 
         .graph-card__content--entering .graph-card__header {
@@ -44791,7 +44799,6 @@ class NodaliaGraphCard extends HTMLElement {
             config.show_header !== false
               ? `
                 <div class="graph-card__header">
-                  <div class="graph-card__title">${escapeHtml(title)}</div>
                   ${
                     config.show_icon !== false
                       ? `
@@ -44802,6 +44809,7 @@ class NodaliaGraphCard extends HTMLElement {
                       `
                       : ""
                   }
+                  <div class="graph-card__title">${escapeHtml(title)}</div>
                 </div>
               `
               : ""
@@ -85183,4 +85191,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.12","contentSha256_12":"68e4cc452084"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.13","contentSha256_12":"69f140fedf7f"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -42221,7 +42221,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.13";
+const CARD_VERSION = "0.12.14";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -44107,6 +44107,34 @@ class NodaliaGraphCard extends HTMLElement {
           animation-delay: 35ms;
         }
 
+        .graph-card__primary-row {
+          align-items: center;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          gap: 10px 14px;
+          justify-content: space-between;
+          min-height: 0;
+          min-width: 0;
+        }
+
+        .graph-card__primary-row .graph-card__value {
+          flex: 0 1 auto;
+          min-width: 0;
+        }
+
+        .graph-card__primary-row .graph-card__legend {
+          flex: 1 1 0;
+          justify-content: flex-end;
+          margin-bottom: 0;
+          min-width: 0;
+        }
+
+        .graph-card__legend--solo {
+          margin-bottom: 4px;
+          width: 100%;
+        }
+
         .graph-card__title {
           color: var(--primary-text-color);
           font-size: ${titleSize};
@@ -44171,7 +44199,8 @@ class NodaliaGraphCard extends HTMLElement {
           min-width: 0;
         }
 
-        .graph-card__content--entering .graph-card__value {
+        .graph-card__content--entering > .graph-card__value,
+        .graph-card__content--entering .graph-card__primary-row .graph-card__value {
           animation: graph-card-section-in calc(var(--graph-card-hover-duration) * 2.2) cubic-bezier(0.18, 0.9, 0.22, 1) both;
           animation-delay: 75ms;
         }
@@ -44198,12 +44227,13 @@ class NodaliaGraphCard extends HTMLElement {
           flex-wrap: wrap;
           gap: 5px 6px;
           justify-content: flex-start;
-          margin-bottom: 4px;
+          margin-bottom: 0;
           min-height: 0;
           padding-top: 0;
         }
 
-        .graph-card__content--entering .graph-card__legend {
+        .graph-card__content--entering > .graph-card__legend,
+        .graph-card__content--entering .graph-card__primary-row .graph-card__legend {
           animation: graph-card-section-in calc(var(--graph-card-hover-duration) * 2.1) cubic-bezier(0.18, 0.9, 0.22, 1) both;
           animation-delay: 105ms;
         }
@@ -44613,6 +44643,7 @@ class NodaliaGraphCard extends HTMLElement {
         .graph-card__hover-point,
         .graph-card__content,
         .graph-card__header,
+        .graph-card__primary-row,
         .graph-card__value,
         .graph-card__legend,
         .graph-card__chart-wrap,
@@ -44630,6 +44661,20 @@ class NodaliaGraphCard extends HTMLElement {
           }
 
           .graph-card__legend {
+            justify-content: flex-start;
+          }
+
+          .graph-card__primary-row {
+            flex-wrap: wrap;
+            row-gap: 6px;
+          }
+
+          .graph-card__primary-row .graph-card__value {
+            flex: 1 1 auto;
+          }
+
+          .graph-card__primary-row .graph-card__legend {
+            flex: 1 1 100%;
             justify-content: flex-start;
           }
         }
@@ -44657,7 +44702,31 @@ class NodaliaGraphCard extends HTMLElement {
           }
 
           ${
-            config.show_value !== false
+            config.show_value !== false && config.show_legend !== false
+              ? `
+                <div class="graph-card__primary-row">
+                  <div class="graph-card__value">
+                    <div class="graph-card__value-number">${escapeHtml(currentValue.value)}</div>
+                    ${currentValue.unit ? `<div class="graph-card__value-unit">${escapeHtml(currentValue.unit)}</div>` : ""}
+                  </div>
+                  <div class="graph-card__legend">
+                    ${legendEntries.map((entry, index) => `
+                      <div
+                        class="graph-card__legend-item ${entry.active ? "graph-card__legend-item--active" : ""} ${entry.muted ? "graph-card__legend-item--muted" : ""}"
+                        data-graph-series="${escapeHtml(entry.entity)}"
+                        style="--legend-color:${escapeHtml(entry.color)}; --legend-delay:${Math.min(index, 8) * 34}ms;"
+                      >
+                        <span class="graph-card__legend-dot" style="background:${escapeHtml(entry.color)};"></span>
+                        <span class="graph-card__legend-text">${escapeHtml(entry.name)}</span>
+                      </div>
+                    `).join("")}
+                  </div>
+                </div>
+              `
+              : ""
+          }
+          ${
+            config.show_value !== false && config.show_legend === false
               ? `
                 <div class="graph-card__value">
                   <div class="graph-card__value-number">${escapeHtml(currentValue.value)}</div>
@@ -44666,11 +44735,10 @@ class NodaliaGraphCard extends HTMLElement {
               `
               : ""
           }
-
           ${
-            config.show_legend !== false
+            config.show_value === false && config.show_legend !== false
               ? `
-                <div class="graph-card__legend">
+                <div class="graph-card__legend graph-card__legend--solo">
                   ${legendEntries.map((entry, index) => `
                     <div
                       class="graph-card__legend-item ${entry.active ? "graph-card__legend-item--active" : ""} ${entry.muted ? "graph-card__legend-item--muted" : ""}"
@@ -72550,7 +72618,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.1";
+const CARD_VERSION = "0.2.2";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -72596,7 +72664,7 @@ const DEFAULT_CONFIG = {
       background: "color-mix(in srgb, var(--primary-text-color) 5%, transparent)",
       on_color: "var(--info-color, #71c0ff)",
       off_color: "var(--state-inactive-color, color-mix(in srgb, var(--primary-text-color) 55%, transparent))",
-      icon_only_offset_y: "2px",
+      icon_only_offset_y: "0",
     },
     tint: {
       color: "var(--info-color, #71c0ff)",
@@ -73434,6 +73502,7 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         :host([data-icon-only]) {
           justify-content: center;
+          overflow: visible;
           width: auto;
         }
 
@@ -73454,6 +73523,10 @@ class NodaliaInsigniaCard extends HTMLElement {
           position: relative;
           overflow: hidden;
           transition: background 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+        }
+
+        .insignia-card.insignia-card--icon-only {
+          overflow: visible;
         }
 
         .insignia-card--icon-only {
@@ -85024,4 +85097,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.1","contentSha256_12":"9b248096f92c"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.2","contentSha256_12":"6a995829c98d"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -11842,6 +11842,227 @@
     "ro": "Vizibilitate"
   },
   {
+    "es": "Insignia",
+    "en": "Insignia",
+    "de": "Insignia",
+    "fr": "Insignia",
+    "it": "Insignia",
+    "nl": "Insignia",
+    "pt": "Insignia",
+    "ru": "Insignia",
+    "el": "Insignia",
+    "zh": "Insignia",
+    "ro": "Insignia"
+  },
+  {
+    "es": "Chip compacto para la barra de insignias: entidad, icono y texto opcionales.",
+    "en": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "de": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "fr": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "it": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "nl": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "pt": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "ru": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "el": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "zh": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "ro": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales."
+  },
+  {
+    "es": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "en": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "de": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "fr": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "it": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "nl": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "pt": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "ru": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "el": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "zh": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "ro": "Vibración al pulsar la insignia (si el dispositivo lo permite)."
+  },
+  {
+    "es": "Acción al pulsar",
+    "en": "Acción al pulsar",
+    "de": "Acción al pulsar",
+    "fr": "Acción al pulsar",
+    "it": "Acción al pulsar",
+    "nl": "Acción al pulsar",
+    "pt": "Acción al pulsar",
+    "ru": "Acción al pulsar",
+    "el": "Acción al pulsar",
+    "zh": "Acción al pulsar",
+    "ro": "Acción al pulsar"
+  },
+  {
+    "es": "Qué ocurre al tocar la insignia.",
+    "en": "Qué ocurre al tocar la insignia.",
+    "de": "Qué ocurre al tocar la insignia.",
+    "fr": "Qué ocurre al tocar la insignia.",
+    "it": "Qué ocurre al tocar la insignia.",
+    "nl": "Qué ocurre al tocar la insignia.",
+    "pt": "Qué ocurre al tocar la insignia.",
+    "ru": "Qué ocurre al tocar la insignia.",
+    "el": "Qué ocurre al tocar la insignia.",
+    "zh": "Qué ocurre al tocar la insignia.",
+    "ro": "Qué ocurre al tocar la insignia."
+  },
+  {
+    "es": "Apariencia",
+    "en": "Apariencia",
+    "de": "Apariencia",
+    "fr": "Apariencia",
+    "it": "Apariencia",
+    "nl": "Apariencia",
+    "pt": "Apariencia",
+    "ru": "Apariencia",
+    "el": "Apariencia",
+    "zh": "Apariencia",
+    "ro": "Apariencia"
+  },
+  {
+    "es": "Tamaños, colores del icono y tinte de la burbuja.",
+    "en": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "de": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "fr": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "it": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "nl": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "pt": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "ru": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "el": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "zh": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "ro": "Tamaños, Colores del Icon y Tint de la burbuja."
+  },
+  {
+    "es": "Mostrar detalles de estilo",
+    "en": "Mostrar detalles de Style",
+    "de": "Mostrar detalles de Style",
+    "fr": "Mostrar detalles de Style",
+    "it": "Mostrar detalles de Style",
+    "nl": "Mostrar detalles de Style",
+    "pt": "Mostrar detalles de Style",
+    "ru": "Mostrar detalles de Style",
+    "el": "Mostrar detalles de Style",
+    "zh": "Mostrar detalles de Style",
+    "ro": "Mostrar detalles de Style"
+  },
+  {
+    "es": "Ocultar detalles de estilo",
+    "en": "Ocultar detalles de Style",
+    "de": "Ocultar detalles de Style",
+    "fr": "Ocultar detalles de Style",
+    "it": "Ocultar detalles de Style",
+    "nl": "Ocultar detalles de Style",
+    "pt": "Ocultar detalles de Style",
+    "ru": "Ocultar detalles de Style",
+    "el": "Ocultar detalles de Style",
+    "zh": "Ocultar detalles de Style",
+    "ro": "Ocultar detalles de Style"
+  },
+  {
+    "es": "Subtitulo",
+    "en": "SubTitle",
+    "de": "SubTitle",
+    "fr": "SubTitle",
+    "it": "SubTitle",
+    "nl": "SubTitle",
+    "pt": "SubTitle",
+    "ru": "SubTitle",
+    "el": "SubTitle",
+    "zh": "SubTitle",
+    "ro": "SubTitle"
+  },
+  {
+    "es": "Subtítulo",
+    "en": "Subtítulo",
+    "de": "Subtítulo",
+    "fr": "Subtítulo",
+    "it": "Subtítulo",
+    "nl": "Subtítulo",
+    "pt": "Subtítulo",
+    "ru": "Subtítulo",
+    "el": "Subtítulo",
+    "zh": "Subtítulo",
+    "ro": "Subtítulo"
+  },
+  {
+    "es": "Posicion",
+    "en": "Posicion",
+    "de": "Posicion",
+    "fr": "Posicion",
+    "it": "Posicion",
+    "nl": "Posicion",
+    "pt": "Posicion",
+    "ru": "Posicion",
+    "el": "Posicion",
+    "zh": "Posicion",
+    "ro": "Posicion"
+  },
+  {
+    "es": "Posición",
+    "en": "Posición",
+    "de": "Posición",
+    "fr": "Posición",
+    "it": "Posición",
+    "nl": "Posición",
+    "pt": "Posición",
+    "ru": "Posición",
+    "el": "Posición",
+    "zh": "Posición",
+    "ro": "Posición"
+  },
+  {
+    "es": "Reproductor",
+    "en": "Player",
+    "de": "Player",
+    "fr": "Player",
+    "it": "Player",
+    "nl": "Player",
+    "pt": "Player",
+    "ru": "Player",
+    "el": "Player",
+    "zh": "Player",
+    "ro": "Player"
+  },
+  {
+    "es": "Principal",
+    "en": "Main",
+    "de": "Main",
+    "fr": "Main",
+    "it": "Main",
+    "nl": "Main",
+    "pt": "Main",
+    "ru": "Main",
+    "el": "Main",
+    "zh": "Main",
+    "ro": "Main"
+  },
+  {
+    "es": "Mostrar ajustes de animacion",
+    "en": "Mostrar ajustes de animacion",
+    "de": "Mostrar ajustes de animacion",
+    "fr": "Mostrar ajustes de animacion",
+    "it": "Mostrar ajustes de animacion",
+    "nl": "Mostrar ajustes de animacion",
+    "pt": "Mostrar ajustes de animacion",
+    "ru": "Mostrar ajustes de animacion",
+    "el": "Mostrar ajustes de animacion",
+    "zh": "Mostrar ajustes de animacion",
+    "ro": "Mostrar ajustes de animacion"
+  },
+  {
+    "es": "Ocultar ajustes de animacion",
+    "en": "Ocultar ajustes de animacion",
+    "de": "Ocultar ajustes de animacion",
+    "fr": "Ocultar ajustes de animacion",
+    "it": "Ocultar ajustes de animacion",
+    "nl": "Ocultar ajustes de animacion",
+    "pt": "Ocultar ajustes de animacion",
+    "ru": "Ocultar ajustes de animacion",
+    "el": "Ocultar ajustes de animacion",
+    "zh": "Ocultar ajustes de animacion",
+    "ro": "Ocultar ajustes de animacion"
+  },
+  {
     "es": "Anadir ruta",
     "en": "Add route",
     "de": "Add route",
@@ -14580,7 +14801,7 @@
     substitutions.forEach(([pattern, replacement]) => {
       out = out.replace(pattern, (match, ...rest) => {
         const groups = rest.slice(0, -2);
-        const expanded = String(replacement).replace(/$(d+)/g, (_, groupIndexRaw) => {
+        const expanded = String(replacement).replace(/\$(\d+)/g, (_, groupIndexRaw) => {
           const groupIndex = Number(groupIndexRaw) - 1;
           return groups[groupIndex] ?? "";
         });
@@ -14589,7 +14810,7 @@
     });
 
     // Clean up legacy literal replacement artifacts left by earlier generator versions.
-    out = out.replace(/$(d+)/g, "");
+    out = out.replace(/\$(\d+)/g, "");
 
     return out;
   }
@@ -21508,6 +21729,29 @@ function getRangeValueFromClientX(slider, clientX) {
   return clamp(nextValue, min, max);
 }
 
+function getSliderDragGeometry(slider) {
+  const rect = slider.getBoundingClientRect();
+  return {
+    left: rect.left,
+    width: rect.width,
+    min: Number(slider.min || 0),
+    max: Number(slider.max || 100),
+    step: slider.step === "any" ? 0 : Number(slider.step || 1),
+  };
+}
+
+function getRangeValueFromGeometry(geometry, currentValue, clientX) {
+  if (!geometry || !Number.isFinite(geometry.width) || geometry.width <= 0) {
+    return Number(currentValue || 0);
+  }
+  const ratio = clamp((clientX - geometry.left) / geometry.width, 0, 1);
+  let nextValue = geometry.min + ((geometry.max - geometry.min) * ratio);
+  if (Number.isFinite(geometry.step) && geometry.step > 0) {
+    nextValue = geometry.min + (Math.round((nextValue - geometry.min) / geometry.step) * geometry.step);
+  }
+  return clamp(nextValue, geometry.min, geometry.max);
+}
+
 function formatDuration(totalSeconds) {
   const safeSeconds = Math.max(0, Math.floor(Number(totalSeconds) || 0));
   const hours = Math.floor(safeSeconds / 3600);
@@ -23082,6 +23326,7 @@ class NodaliaMediaPlayer extends HTMLElement {
     this._activeSliderDrag = {
       pointerId,
       slider,
+      geometry: getSliderDragGeometry(slider),
     };
 
     if (event) {
@@ -23095,7 +23340,7 @@ class NodaliaMediaPlayer extends HTMLElement {
       this._dragFrame = 0;
     }
 
-    const nextValue = getRangeValueFromClientX(slider, clientX);
+    const nextValue = getRangeValueFromGeometry(this._activeSliderDrag.geometry, slider.value, clientX);
     slider.value = String(nextValue);
 
     if (slider.dataset.mediaSlider === "volume") {
@@ -23105,7 +23350,7 @@ class NodaliaMediaPlayer extends HTMLElement {
   }
 
   _queueSliderDragUpdate(slider, clientX) {
-    const nextValue = getRangeValueFromClientX(slider, clientX);
+    const nextValue = getRangeValueFromGeometry(this._activeSliderDrag?.geometry, slider.value, clientX);
     slider.value = String(nextValue);
 
     if (slider.dataset.mediaSlider === "volume") {
@@ -23130,7 +23375,7 @@ class NodaliaMediaPlayer extends HTMLElement {
       this._dragFrame = 0;
     }
 
-    const nextValue = getRangeValueFromClientX(drag.slider, clientX);
+    const nextValue = getRangeValueFromGeometry(drag.geometry, drag.slider.value, clientX);
     drag.slider.value = String(nextValue);
     this._skipNextSliderChange = drag.slider;
 
@@ -39803,6 +40048,57 @@ function escapeSelectorValue(value) {
   return String(value ?? "").replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
+function sanitizeCssValue(value, fallback) {
+  const raw = String(value ?? "").trim();
+  const safeFallback = String(fallback ?? "").trim();
+  if (!raw) {
+    return safeFallback;
+  }
+  if (/[\u0000-\u001f\u007f<>;"'{}]/.test(raw) || raw.includes("/*") || raw.includes("*/")) {
+    return safeFallback;
+  }
+  return raw;
+}
+
+function getSafeStyles(styles = DEFAULT_CONFIG.styles) {
+  const defaults = DEFAULT_CONFIG.styles;
+  const card = styles?.card || {};
+  const icon = styles?.icon || {};
+  const gauge = styles?.gauge || {};
+  return {
+    card: {
+      background: sanitizeCssValue(card.background, defaults.card.background),
+      border: sanitizeCssValue(card.border, defaults.card.border),
+      border_radius: sanitizeCssValue(card.border_radius, defaults.card.border_radius),
+      box_shadow: sanitizeCssValue(card.box_shadow, defaults.card.box_shadow),
+      padding: sanitizeCssValue(card.padding, defaults.card.padding),
+      gap: sanitizeCssValue(card.gap, defaults.card.gap),
+    },
+    icon: {
+      size: sanitizeCssValue(icon.size, defaults.icon.size),
+      background: sanitizeCssValue(icon.background, defaults.icon.background),
+      color: sanitizeCssValue(icon.color, defaults.icon.color),
+    },
+    chip_height: sanitizeCssValue(styles?.chip_height, defaults.chip_height),
+    chip_font_size: sanitizeCssValue(styles?.chip_font_size, defaults.chip_font_size),
+    chip_padding: sanitizeCssValue(styles?.chip_padding, defaults.chip_padding),
+    title_size: sanitizeCssValue(styles?.title_size, defaults.title_size),
+    value_size: sanitizeCssValue(styles?.value_size, defaults.value_size),
+    range_size: sanitizeCssValue(styles?.range_size, defaults.range_size),
+    name_chip_max_width: sanitizeCssValue(styles?.name_chip_max_width, defaults.name_chip_max_width),
+    gauge: {
+      size: sanitizeCssValue(gauge.size, defaults.gauge.size),
+      stroke: sanitizeCssValue(gauge.stroke, defaults.gauge.stroke),
+      thumb_size: sanitizeCssValue(gauge.thumb_size, defaults.gauge.thumb_size),
+      track_color: sanitizeCssValue(gauge.track_color, defaults.gauge.track_color),
+      background: sanitizeCssValue(gauge.background, defaults.gauge.background),
+      min_tint_color: sanitizeCssValue(gauge.min_tint_color, defaults.gauge.min_tint_color),
+      max_tint_color: sanitizeCssValue(gauge.max_tint_color, defaults.gauge.max_tint_color),
+      foreground_color: sanitizeCssValue(gauge.foreground_color, defaults.gauge.foreground_color),
+    },
+  };
+}
+
 function resolveEditorColorValue(value) {
   const rawValue = String(value ?? "").trim();
   if (!rawValue || typeof document === "undefined") {
@@ -40589,7 +40885,7 @@ class NodaliaCircularGaugeCard extends HTMLElement {
     }
 
     const config = this._config || normalizeConfig({});
-    const styles = config.styles || DEFAULT_CONFIG.styles;
+    const styles = getSafeStyles(config.styles);
     const state = this._getState();
 
     if (!state) {
@@ -40610,7 +40906,8 @@ class NodaliaCircularGaugeCard extends HTMLElement {
     const dialAngle = DIAL_START_ANGLE + (ratio * DIAL_SWEEP);
     const thumbPosition = getDialMarkerPosition(dialAngle);
     const dialStartCoordinates = getDialMarkerCoordinates(DIAL_START_ANGLE);
-    const dialStartCapColor = String(styles.gauge.foreground_color || "").trim() || resolveGaugeTintColor(tintScale, 0.02);
+    const dialStartCapColor =
+      sanitizeCssValue(styles.gauge.foreground_color, "") || resolveGaugeTintColor(tintScale, 0.02);
     const showUnavailableBadge = config.show_unavailable_badge !== false && isUnavailableState(state);
     const showHeader = config.show_header !== false;
     const showName = config.show_name !== false;
@@ -41256,7 +41553,7 @@ class NodaliaCircularGaugeCard extends HTMLElement {
                       cx="${DIAL_VIEWBOX_SIZE / 2}"
                       cy="${DIAL_VIEWBOX_SIZE / 2}"
                       r="${DIAL_CIRCLE_RADIUS}"
-                      style="stroke:${segment.color};stroke-dasharray:${segment.dasharray};stroke-dashoffset:${segment.dashoffset};opacity:${segment.opacity};"
+                      style="stroke:${sanitizeCssValue(segment.color, styles.gauge.max_tint_color)};stroke-dasharray:${segment.dasharray};stroke-dashoffset:${segment.dashoffset};opacity:${segment.opacity};"
                     ></circle>
                   `)
                   .join("")}
@@ -41266,7 +41563,7 @@ class NodaliaCircularGaugeCard extends HTMLElement {
                   cx="${dialStartCoordinates.x}"
                   cy="${dialStartCoordinates.y}"
                   r="${Number((dialStrokePx / 2).toFixed(3))}"
-                  style="fill:${dialStartCapColor};"
+                  style="fill:${sanitizeCssValue(dialStartCapColor, styles.gauge.max_tint_color)};"
                 ></circle>
               </svg>
               <span class="gauge-card__dial-thumb" aria-hidden="true"></span>
@@ -44170,9 +44467,11 @@ class NodaliaGraphCard extends HTMLElement {
 
     tooltip.style.left = `${resolvedCenter}px`;
     tooltip.style.top = `${resolvedTop}px`;
-    tooltip.style.setProperty("--graph-tooltip-transform", shouldShowBelow
-      ? "translate(-50%, 0)"
-      : "translate(-50%, -100%)");
+    tooltip.style.setProperty(
+      "--graph-tooltip-transform",
+      shouldShowBelow ? "translate(-50%, 0)" : "translate(-50%, -100%)",
+    );
+    tooltip.style.opacity = "1";
   }
 
   _getSeriesData() {
@@ -44277,7 +44576,7 @@ class NodaliaGraphCard extends HTMLElement {
         <div
           class="graph-card__tooltip ${this._hoverEntering && animations.enabled ? "graph-card__tooltip--entering" : ""}"
           data-anchor-x-pct="${anchorXPct.toFixed(4)}"
-          style="left:${anchorXPct.toFixed(3)}%; --tooltip-tint:${escapeHtml(tooltipTint)};"
+          style="left:-9999px; top:-9999px; opacity:0; --tooltip-tint:${escapeHtml(tooltipTint)};"
         >
           <div class="graph-card__tooltip-time">${escapeHtml(hover.label)}</div>
           <div class="graph-card__tooltip-values">
@@ -52067,6 +52366,8 @@ class NodaliaClimateCard extends HTMLElement {
     this._temperatureCommitInFlight = false;
     this._temperatureCommitRetryCount = 0;
     this._activeDialDrag = null;
+    this._dialDragFrame = 0;
+    this._pendingDialDragPoint = null;
     this._pendingRenderAfterDrag = false;
     this._lastRenderSignature = "";
     this._animateContentOnNextRender = true;
@@ -52135,6 +52436,11 @@ class NodaliaClimateCard extends HTMLElement {
       window.clearTimeout(this._entranceAnimationResetTimer);
       this._entranceAnimationResetTimer = 0;
     }
+    if (this._dialDragFrame) {
+      window.cancelAnimationFrame(this._dialDragFrame);
+      this._dialDragFrame = 0;
+    }
+    this._pendingDialDragPoint = null;
     this._animateContentOnNextRender = true;
     this._lastRenderSignature = "";
   }
@@ -52858,6 +53164,22 @@ class NodaliaClimateCard extends HTMLElement {
     this._applyDialValue(nextValue, { commit: false });
   }
 
+  _queueDialDragMove(clientX, clientY, event = null) {
+    this._pendingDialDragPoint = { clientX, clientY, event };
+    if (this._dialDragFrame) {
+      return;
+    }
+    this._dialDragFrame = window.requestAnimationFrame(() => {
+      this._dialDragFrame = 0;
+      const pending = this._pendingDialDragPoint;
+      this._pendingDialDragPoint = null;
+      if (!pending) {
+        return;
+      }
+      this._moveDialDrag(pending.clientX, pending.clientY, pending.event);
+    });
+  }
+
   _commitDialDrag(clientX, clientY, event = null, pointerId = null) {
     const drag = this._activeDialDrag;
     const state = this._getState();
@@ -52869,6 +53191,11 @@ class NodaliaClimateCard extends HTMLElement {
     if (event) {
       event.preventDefault();
     }
+    if (this._dialDragFrame) {
+      window.cancelAnimationFrame(this._dialDragFrame);
+      this._dialDragFrame = 0;
+    }
+    this._pendingDialDragPoint = null;
 
     const nextValue = getDialValueFromPoint(
       drag.dial,
@@ -52963,7 +53290,7 @@ class NodaliaClimateCard extends HTMLElement {
       return;
     }
 
-    this._moveDialDrag(event.clientX, event.clientY, event);
+    this._queueDialDragMove(event.clientX, event.clientY, event);
   }
 
   _onWindowPointerUp(event) {
@@ -52980,7 +53307,7 @@ class NodaliaClimateCard extends HTMLElement {
       return;
     }
 
-    this._moveDialDrag(event.clientX, event.clientY, event);
+    this._queueDialDragMove(event.clientX, event.clientY, event);
   }
 
   _onWindowMouseUp(event) {
@@ -52996,7 +53323,7 @@ class NodaliaClimateCard extends HTMLElement {
       return;
     }
 
-    this._moveDialDrag(event.touches[0].clientX, event.touches[0].clientY, event);
+    this._queueDialDragMove(event.touches[0].clientX, event.touches[0].clientY, event);
   }
 
   _onWindowTouchStartCapture(event) {
@@ -59808,6 +60135,7 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
     this._lastRenderSignature = "";
     this._animateContentOnNextRender = true;
     this._entranceAnimationResetTimer = 0;
+    this._mapActionInFlight = false;
 
     this._onShadowClick = this._onShadowClick.bind(this);
     this._onShadowChange = this._onShadowChange.bind(this);
@@ -63344,6 +63672,11 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
   }
 
   async _runMapAction() {
+    if (this._mapActionInFlight) {
+      return;
+    }
+    this._mapActionInFlight = true;
+    try {
     const state = this._getVacuumState();
     const selectedPredefinedZones = this._getPredefinedZones()
       .filter(zone => this._selectedPredefinedZoneIds.includes(zone.id))
@@ -63427,7 +63760,8 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
           command: "app_zoned_clean",
           params: selectedZones,
         });
-        const activeCleaningSessionMode = this._isRoomCleaningSessionActive(state) ? "rooms" : "zone";
+        const latestState = this._getVacuumState();
+        const activeCleaningSessionMode = this._isRoomCleaningSessionActive(latestState) ? "rooms" : "zone";
         if (!this._restoreTransientZoneMode()) {
           this._selectedManualZoneIndex = -1;
           this._draftZone = null;
@@ -63466,6 +63800,9 @@ class NodaliaAdvanceVacuumCard extends HTMLElement {
     this._clearPersistedCleaningSession();
     await this._callVacuumService("start");
     this._triggerHaptic("selection");
+    } finally {
+      this._mapActionInFlight = false;
+    }
   }
 
   _runCustomMenuItem(item) {
@@ -85512,4 +85849,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.15","contentSha256_12":"92311cc34a35"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.16","contentSha256_12":"65441736f930"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -14613,6 +14613,304 @@
 
 }
 {
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  if (typeof window !== "undefined" && window.NodaliaUtils?.stripEqualToDefaults && window.NodaliaUtils?.deepEqual) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Cheap signature when the editor only needs to know if hass/stale registry size changed.
+   * Includes locale tag so language switches still re-render translated labels.
+   */
+  function editorStatesSignature(hass, language) {
+    const count = Object.keys(hass?.states || {}).length;
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${count}`;
+  }
+
+  /**
+   * Count entities matching predicate(entityId); same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    let n = 0;
+    for (const id of Object.keys(states)) {
+      if (predicate(id)) {
+        n += 1;
+      }
+    }
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${n}`;
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      if (control.tagName === "INPUT") {
+        control.addEventListener("change", onShadowInput);
+      } else {
+        control.addEventListener("value-changed", onShadowValueChanged || onShadowInput);
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      if (control.tagName === "INPUT") {
+        control.addEventListener("change", onShadowInput);
+      } else {
+        control.addEventListener("value-changed", onShadowValueChanged || onShadowInput);
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+}
+{
 (function initNodaliaBubbleContrast() {
   const existing = typeof window !== "undefined" ? window.NodaliaBubbleContrast : null;
   if (existing && typeof existing.shouldDarkenBubbleIconGlyph === "function") {
@@ -14633,10 +14931,15 @@
     return entityId.includes(".") ? entityId.split(".")[0] : "";
   }
 
+  const resolveEditorColorValueCache = new Map();
+
   function resolveEditorColorValue(value) {
     const rawValue = String(value ?? "").trim();
     if (!rawValue || typeof document === "undefined") {
       return "";
+    }
+    if (resolveEditorColorValueCache.has(rawValue)) {
+      return resolveEditorColorValueCache.get(rawValue);
     }
 
     const probe = document.createElement("span");
@@ -14646,13 +14949,16 @@
     probe.style.color = "";
     probe.style.color = rawValue;
     if (!probe.style.color) {
+      resolveEditorColorValueCache.set(rawValue, rawValue);
       return rawValue;
     }
 
     (document.body || document.documentElement).appendChild(probe);
     const resolved = getComputedStyle(probe).color;
     probe.remove();
-    return resolved || rawValue;
+    const result = resolved || rawValue;
+    resolveEditorColorValueCache.set(rawValue, result);
+    return result;
   }
 
   function rgbToHueDegrees(r, g, b) {
@@ -15153,71 +15459,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -19074,85 +19315,27 @@ class NodaliaNavigationBarEditor extends HTMLElement {
     `;
   }
 
-  _copyDatasetToControl(host, control) {
-    Object.entries(host.dataset || {}).forEach(([key, value]) => {
-      if (key === "mountedControl" || key === "value" || key === "placeholder") {
-        return;
-      }
-      control.dataset[key] = value;
+  _mountEntityPicker(host) {
+    window.NodaliaUtils.mountEntityPickerHost(host, {
+      hass: this._hass,
+      field: host.dataset.field || "entity",
+      value: host.dataset.value || "",
+      placeholder: host.dataset.placeholder || "",
+      onShadowInput: this._onShadowInput,
+      onShadowValueChanged: this._onShadowInput,
+      copyDatasetFromHost: true,
     });
   }
 
-  _mountEntityPicker(host) {
-    if (!(host instanceof HTMLElement)) {
-      return;
-    }
-
-    const nextValue = host.dataset.value || "";
-    const placeholder = host.dataset.placeholder || "";
-    let control = null;
-
-    if (customElements.get("ha-entity-picker")) {
-      control = document.createElement("ha-entity-picker");
-      control.allowCustomEntity = true;
-    } else if (customElements.get("ha-selector")) {
-      control = document.createElement("ha-selector");
-      control.selector = { entity: {} };
-    } else {
-      control = document.createElement("input");
-      control.type = "text";
-    }
-
-    this._copyDatasetToControl(host, control);
-
-    if ("hass" in control) {
-      control.hass = this._hass;
-    }
-    if (placeholder && "placeholder" in control) {
-      control.placeholder = placeholder;
-    }
-    if ("value" in control) {
-      control.value = nextValue;
-    }
-    if (control.tagName !== "INPUT") {
-      control.addEventListener("value-changed", this._onShadowInput);
-    }
-
-    host.replaceChildren(control);
-  }
-
   _mountIconPicker(host) {
-    if (!(host instanceof HTMLElement)) {
-      return;
-    }
-
-    const nextValue = host.dataset.value || "";
-    const placeholder = host.dataset.placeholder || "";
-    let control = null;
-
-    if (customElements.get("ha-icon-picker")) {
-      control = document.createElement("ha-icon-picker");
-    } else {
-      control = document.createElement("input");
-      control.type = "text";
-    }
-
-    this._copyDatasetToControl(host, control);
-
-    if ("hass" in control) {
-      control.hass = this._hass;
-    }
-    if (placeholder && "placeholder" in control) {
-      control.placeholder = placeholder;
-    }
-    if ("value" in control) {
-      control.value = nextValue;
-    }
-    if (control.tagName !== "INPUT") {
-      control.addEventListener("value-changed", this._onShadowInput);
-    }
-
-    host.replaceChildren(control);
+    window.NodaliaUtils.mountIconPickerHost(host, {
+      hass: this._hass,
+      value: host.dataset.value || "",
+      placeholder: host.dataset.placeholder || "",
+      onShadowInput: this._onShadowInput,
+      onShadowValueChanged: this._onShadowInput,
+      copyDatasetFromHost: true,
+    });
   }
 
   _prepareEditorConfig(config) {
@@ -19293,7 +19476,7 @@ class NodaliaNavigationBarEditor extends HTMLElement {
     this._restoreFocusState(focusState);
     const merged = mergeConfig(DEFAULT_CONFIG, prepared);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(merged, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(merged, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -20839,71 +21022,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function normalizePowerActionConfig(action) {
   if (!isObject(action)) {
@@ -25779,11 +25897,7 @@ class NodaliaMediaPlayerEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("media_player."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id => id.startsWith("media_player."));
   }
 
   _getEntityOptions(field = "players.0.entity", domains = []) {
@@ -25874,7 +25988,7 @@ class NodaliaMediaPlayerEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -27218,71 +27332,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -30866,11 +30915,7 @@ class NodaliaLightCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("light."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id => id.startsWith("light."));
   }
 
   _getLightEntityOptions() {
@@ -30983,7 +31028,7 @@ class NodaliaLightCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -31962,71 +32007,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -34399,11 +34379,7 @@ class NodaliaFanCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("fan."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id => id.startsWith("fan."));
   }
 
   _getFanEntityOptions() {
@@ -34516,7 +34492,7 @@ class NodaliaFanCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -35570,71 +35546,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -38288,11 +38199,12 @@ class NodaliaHumidifierCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("humidifier.") || entityId.startsWith("select.") || entityId.startsWith("input_select."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(
+      hass,
+      this._config?.language,
+      id =>
+        id.startsWith("humidifier.") || id.startsWith("select.") || id.startsWith("input_select."),
+    );
   }
 
   _getHumidifierEntityOptions() {
@@ -38435,7 +38347,7 @@ class NodaliaHumidifierCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -39638,71 +39550,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -41391,15 +41238,9 @@ class NodaliaCircularGaugeCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => (
-        entityId.startsWith("sensor.")
-        || entityId.startsWith("number.")
-        || entityId.startsWith("input_number.")
-      ))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id =>
+      id.startsWith("sensor.") || id.startsWith("number.") || id.startsWith("input_number."),
+    );
   }
 
   _getNumericEntityOptions() {
@@ -41515,7 +41356,7 @@ class NodaliaCircularGaugeCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -42380,7 +42221,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.12";
+const CARD_VERSION = "0.12.13";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -42435,17 +42276,17 @@ const DEFAULT_CONFIG = {
       border_radius: "30px",
       box_shadow: "var(--ha-card-box-shadow)",
       padding: "16px",
-      gap: "12px",
+      gap: "10px",
     },
     icon: {
       color: "var(--primary-text-color)",
       size: "28px",
     },
-    title_size: "15px",
-    value_size: "52px",
-    unit_size: "20px",
-    legend_size: "13px",
-    chart_height: "170px",
+    title_size: "13px",
+    value_size: "40px",
+    unit_size: "17px",
+    legend_size: "11px",
+    chart_height: "178px",
     line_width: "1px",
   },
 };
@@ -42555,71 +42396,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -42727,6 +42503,33 @@ function inferDecimals(rawValue) {
 function parseSizeToPixels(value, fallback = 0) {
   const numeric = Number.parseFloat(String(value ?? ""));
   return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+/** Parses CSS padding shorthand into edge pixel values (numbers only tokens). */
+function parsePaddingEdges(value, fallback = 16) {
+  const fb = Number.isFinite(fallback) ? fallback : 16;
+  const raw = String(value ?? "").trim();
+  if (!raw) {
+    return { top: fb, right: fb, bottom: fb, left: fb };
+  }
+  const parts = raw.split(/\s+/).map(token => parseSizeToPixels(token, NaN)).filter(n => Number.isFinite(n));
+  if (!parts.length) {
+    return { top: fb, right: fb, bottom: fb, left: fb };
+  }
+  if (parts.length === 1) {
+    const v = parts[0];
+    return { top: v, right: v, bottom: v, left: v };
+  }
+  if (parts.length === 2) {
+    const [vertical, horizontal] = parts;
+    return { top: vertical, right: horizontal, bottom: vertical, left: horizontal };
+  }
+  if (parts.length === 3) {
+    const [top, horizontal, bottom] = parts;
+    return { top, right: horizontal, bottom, left: horizontal };
+  }
+  const [top, right, bottom, left] = parts;
+  return { top, right, bottom, left };
 }
 
 function clamp(value, min, max) {
@@ -44199,14 +44002,18 @@ class NodaliaGraphCard extends HTMLElement {
     const icon = this._getIcon();
     const title = this._getTitle();
     const accentColor = chart.entries[0]?.color || legendEntries[0]?.color || "var(--primary-color)";
-    const chartHeight = `${Math.max(120, Math.min(parseSizeToPixels(styles.chart_height, 150), compactLayout ? 132 : 150))}px`;
-    const valueSize = `${Math.max(38, Math.min(parseSizeToPixels(styles.value_size, 46), compactLayout ? 42 : 46))}px`;
-    const unitSize = `${Math.max(15, Math.min(parseSizeToPixels(styles.unit_size, 18), compactLayout ? 16 : 18))}px`;
-    const titleSize = `${Math.max(13, Math.min(parseSizeToPixels(styles.title_size, 14), compactLayout ? 13 : 14))}px`;
-    const legendSize = `${Math.max(11, Math.min(parseSizeToPixels(styles.legend_size, 12), compactLayout ? 11 : 12))}px`;
+    const chartHeight = `${Math.max(136, Math.min(parseSizeToPixels(styles.chart_height, 150), compactLayout ? 148 : 172))}px`;
+    const valueSize = `${Math.max(26, Math.min(parseSizeToPixels(styles.value_size, 52), compactLayout ? 32 : 38))}px`;
+    const unitSize = `${Math.max(12, Math.min(parseSizeToPixels(styles.unit_size, 18), compactLayout ? 14 : 16))}px`;
+    const titleSize = `${Math.max(11, Math.min(parseSizeToPixels(styles.title_size, 14), compactLayout ? 11.5 : 12.5))}px`;
+    const legendSize = `${Math.max(10, Math.min(parseSizeToPixels(styles.legend_size, 12), compactLayout ? 10 : 11))}px`;
     const lineWidth = `${Math.max(1.6, Math.min(parseSizeToPixels(styles.line_width, 2.2), compactLayout ? 1.9 : 2.2))}`;
-    const cardPaddingPx = Math.max(12, parseSizeToPixels(styles.card.padding, 16));
-    const chartBleed = Math.round(cardPaddingPx * 0.95);
+    const padEdges = parsePaddingEdges(styles.card.padding, 16);
+    const cardPaddingPx = Math.max(12, Math.round((padEdges.left + padEdges.right) / 2));
+    const chartBleed = Math.round(Math.max(padEdges.left, padEdges.right, cardPaddingPx) * 0.98);
+    const chartBleedLeft = Math.round(padEdges.left);
+    const chartBleedRight = Math.round(padEdges.right);
+    const chartBleedBottom = Math.round(padEdges.bottom);
     const cardBackground = `linear-gradient(180deg, color-mix(in srgb, ${accentColor} 8%, color-mix(in srgb, var(--primary-text-color) 2%, transparent)) 0%, ${styles.card.background} 100%)`;
     const computedCardBorder = `1px solid color-mix(in srgb, ${accentColor} 20%, var(--divider-color))`;
     const cardBorder = String(styles.card.border || "").trim() && styles.card.border !== DEFAULT_CONFIG.styles.card.border
@@ -44291,7 +44098,7 @@ class NodaliaGraphCard extends HTMLElement {
         .graph-card__header {
           align-items: start;
           display: grid;
-          gap: 10px;
+          gap: 8px;
           grid-template-columns: minmax(0, 1fr) auto;
         }
 
@@ -44316,13 +44123,13 @@ class NodaliaGraphCard extends HTMLElement {
           align-items: center;
           background: linear-gradient(180deg, color-mix(in srgb, var(--primary-text-color) 6%, transparent) 0%, color-mix(in srgb, var(--primary-text-color) 3%, transparent) 100%);
           border: 1px solid color-mix(in srgb, var(--primary-text-color) 8%, transparent);
-          border-radius: 20px;
+          border-radius: 18px;
           color: ${styles.icon.color};
           display: inline-flex;
-          height: 42px;
+          height: 38px;
           justify-content: center;
           opacity: 0.9;
-          padding: 0 12px;
+          padding: 0 10px;
           position: relative;
         }
 
@@ -44389,9 +44196,9 @@ class NodaliaGraphCard extends HTMLElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 6px 8px;
+          gap: 5px 6px;
           justify-content: flex-start;
-          margin-bottom: 8px;
+          margin-bottom: 4px;
           min-height: 0;
           padding-top: 0;
         }
@@ -44409,12 +44216,12 @@ class NodaliaGraphCard extends HTMLElement {
           color: var(--primary-text-color);
           cursor: pointer;
           display: inline-flex;
-          font-size: max(11px, calc(${legendSize} - 1px));
-          gap: 8px;
-          max-width: min(100%, 192px);
+          font-size: max(10px, calc(${legendSize} - 1px));
+          gap: 6px;
+          max-width: min(100%, 184px);
           min-width: 0;
           opacity: 0.9;
-          padding: 5px 9px;
+          padding: 4px 8px;
           transform: translateZ(0);
           transform-origin: center;
           transition: opacity 160ms ease, transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
@@ -44460,19 +44267,20 @@ class NodaliaGraphCard extends HTMLElement {
             linear-gradient(180deg, color-mix(in srgb, ${accentColor} 8%, transparent) 0%, transparent 62%),
             color-mix(in srgb, var(--primary-text-color) 2%, transparent);
           border: 1px solid color-mix(in srgb, var(--primary-text-color) 7%, transparent);
-          border-radius: 20px;
+          border-radius: ${styles.card.border_radius};
           box-shadow: inset 0 1px 0 color-mix(in srgb, var(--primary-text-color) 5%, transparent);
           flex: 1 1 auto;
+          margin: 6px -${chartBleedRight}px -${chartBleedBottom}px -${chartBleedLeft}px;
+          max-width: none;
           min-height: ${chartHeight};
-          margin-inline: 0;
-          margin-top: 14px;
+          min-width: 0;
           overflow: hidden;
-          padding: 4px 0 14px;
+          padding: 4px 0 12px;
           position: relative;
           touch-action: pan-y;
           user-select: none;
           -webkit-user-select: none;
-          width: 100%;
+          width: calc(100% + ${chartBleedLeft + chartBleedRight}px);
         }
 
         .graph-card__chart-wrap--entering {
@@ -44981,14 +44789,9 @@ class NodaliaGraphCardEditorLegacy extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass) {
-    if (!hass?.states) {
-      return "";
-    }
-
-    return Object.keys(hass.states)
-      .filter(entityId => entityId.startsWith("sensor.") || entityId.startsWith("number.") || entityId.startsWith("input_number."))
-      .sort((left, right) => left.localeCompare(right, "es"))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id =>
+      id.startsWith("sensor.") || id.startsWith("number.") || id.startsWith("input_number."),
+    );
   }
 
   _captureFocusState() {
@@ -45065,7 +44868,7 @@ class NodaliaGraphCardEditorLegacy extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -45599,15 +45402,9 @@ class NodaliaGraphCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => (
-        entityId.startsWith("sensor.")
-        || entityId.startsWith("number.")
-        || entityId.startsWith("input_number.")
-      ))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id =>
+      id.startsWith("sensor.") || id.startsWith("number.") || id.startsWith("input_number."),
+    );
   }
 
   _getEntityOptions(field = "entities.0.entity", domains = []) {
@@ -45732,7 +45529,7 @@ class NodaliaGraphCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -46996,71 +46793,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -49731,14 +49463,9 @@ class NodaliaPowerFlowCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass) {
-    if (!hass?.states) {
-      return "";
-    }
-
-    return Object.keys(hass.states)
-      .filter(entityId => entityId.startsWith("sensor.") || entityId.startsWith("number.") || entityId.startsWith("input_number."))
-      .sort((left, right) => left.localeCompare(right, "es"))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id =>
+      id.startsWith("sensor.") || id.startsWith("number.") || id.startsWith("input_number."),
+    );
   }
 
   _captureFocusState() {
@@ -49815,7 +49542,7 @@ class NodaliaPowerFlowCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -50382,11 +50109,9 @@ class NodaliaPowerFlowCardVisualEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("sensor.") || entityId.startsWith("number.") || entityId.startsWith("input_number."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id =>
+      id.startsWith("sensor.") || id.startsWith("number.") || id.startsWith("input_number."),
+    );
   }
 
   _watchEditorControlTag(tagName) {
@@ -50532,7 +50257,7 @@ class NodaliaPowerFlowCardVisualEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -51595,71 +51320,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -54154,10 +53814,7 @@ class NodaliaClimateCardEditorLegacy extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.keys(hass?.states || {})
-      .filter(entityId => entityId.startsWith("climate."))
-      .sort((left, right) => left.localeCompare(right, "es"))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id => id.startsWith("climate."));
   }
 
   _captureFocusState() {
@@ -54240,7 +53897,7 @@ class NodaliaClimateCardEditorLegacy extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -54732,11 +54389,7 @@ class NodaliaClimateCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("climate."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id => id.startsWith("climate."));
   }
 
   _getClimateEntityOptions() {
@@ -54849,7 +54502,7 @@ class NodaliaClimateCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -55883,71 +55536,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -57413,11 +57001,12 @@ class NodaliaAlarmPanelCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("alarm_control_panel.") || entityId.startsWith("input_text."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(
+      hass,
+      this._config?.language,
+      id =>
+        id.startsWith("alarm_control_panel.") || id.startsWith("input_text."),
+    );
   }
 
   _watchEditorControlTag(tagName) {
@@ -57567,7 +57156,7 @@ class NodaliaAlarmPanelCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -58847,71 +58436,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -66218,9 +65742,7 @@ class NodaliaAdvanceVacuumCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.keys(hass?.states || {})
-      .sort((left, right) => left.localeCompare(right, "es"))
-      .join("|");
+    return window.NodaliaUtils.editorStatesSignature(hass, this._config?.language);
   }
 
   _captureFocusState() {
@@ -66302,7 +65824,7 @@ class NodaliaAdvanceVacuumCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(deepClone(this._config), DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(deepClone(this._config), DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -67283,71 +66805,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -68878,11 +68335,7 @@ class NodaliaEntityCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    const tag = window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, this._config?.language));
-    return `${tag}|${Object.entries(hass?.states || {})
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, tag, { sensitivity: "base" }))
-      .join("|")}`;
+    return window.NodaliaUtils.editorStatesSignature(hass, this._config?.language);
   }
 
   _watchEditorControlTag(tagName) {
@@ -69028,7 +68481,7 @@ class NodaliaEntityCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -69330,28 +68783,28 @@ class NodaliaEntityCardEditor extends HTMLElement {
       return;
     }
 
+    if (customElements.get("ha-entity-picker") || customElements.get("ha-selector")) {
+      window.NodaliaUtils.mountEntityPickerHost(host, {
+        hass: this._hass,
+        field: host.dataset.field || "entity",
+        value: host.dataset.value || "",
+        onShadowInput: this._onShadowInput,
+        onShadowValueChanged: this._onShadowValueChanged,
+        copyDatasetFromHost: true,
+      });
+      return;
+    }
+
     const field = host.dataset.field || "entity";
     const nextValue = host.dataset.value || "";
-    let control = null;
-
-    if (customElements.get("ha-entity-picker")) {
-      control = document.createElement("ha-entity-picker");
-      control.allowCustomEntity = true;
-    } else if (customElements.get("ha-selector")) {
-      control = document.createElement("ha-selector");
-      control.selector = {
-        entity: {},
-      };
-    } else {
-      control = document.createElement("select");
-      this._getEntityOptions(field).forEach(option => {
-        const optionElement = document.createElement("option");
-        optionElement.value = option.value;
-        optionElement.textContent = option.displayLabel;
-        control.appendChild(optionElement);
-      });
-      control.addEventListener("change", this._onShadowInput);
-    }
+    const control = document.createElement("select");
+    this._getEntityOptions(field).forEach(option => {
+      const optionElement = document.createElement("option");
+      optionElement.value = option.value;
+      optionElement.textContent = option.displayLabel;
+      control.appendChild(optionElement);
+    });
+    control.addEventListener("change", this._onShadowInput);
 
     control.dataset.field = field;
     control.dataset.value = nextValue;
@@ -69362,10 +68815,6 @@ class NodaliaEntityCardEditor extends HTMLElement {
 
     if ("value" in control) {
       control.value = nextValue;
-    }
-
-    if (control.tagName !== "SELECT") {
-      control.addEventListener("value-changed", this._onShadowValueChanged);
     }
 
     host.replaceChildren(control);
@@ -70211,71 +69660,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -72184,10 +71568,7 @@ class NodaliaFavCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorStatesSignature(hass, this._config?.language);
   }
 
   _getEntityOptions(field = "entity", domains = []) {
@@ -72307,7 +71688,7 @@ class NodaliaFavCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -73169,7 +72550,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.0";
+const CARD_VERSION = "0.2.1";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -73184,6 +72565,8 @@ const DEFAULT_CONFIG = {
   entity: "",
   name: "",
   icon: "",
+  icon_active: "",
+  icon_inactive: "",
   use_entity_icon: false,
   use_entity_picture: false,
   state_attribute: "",
@@ -73326,71 +72709,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -73776,12 +73094,33 @@ class NodaliaInsigniaCard extends HTMLElement {
     return unit ? `${formatted} ${unit}` : formatted;
   }
 
-  _getResolvedIcon(state) {
-    if (this._config.use_entity_icon) {
-      return getDynamicEntityIcon(state) || this._config.icon || "mdi:star-four-points-circle";
+  _isActiveState(state) {
+    const stateKey = normalizeTextKey(state?.state);
+
+    if (!stateKey || ["off", "closed", "locked", "unavailable", "unknown", "none", "idle", "standby"].includes(stateKey)) {
+      return false;
     }
 
-    return this._config.icon || state?.attributes?.icon || "mdi:star-four-points-circle";
+    return true;
+  }
+
+  _getResolvedIcon(state) {
+    const trimIcon = value => (typeof value === "string" ? value.trim() : "");
+    const iconActive = trimIcon(this._config?.icon_active);
+    const iconInactive = trimIcon(this._config?.icon_inactive);
+
+    if (iconActive || iconInactive) {
+      const chosen = this._isActiveState(state) ? iconActive : iconInactive;
+      if (chosen) {
+        return chosen;
+      }
+    }
+
+    if (this._config.use_entity_icon) {
+      return getDynamicEntityIcon(state) || trimIcon(this._config?.icon) || "mdi:star-four-points-circle";
+    }
+
+    return trimIcon(this._config?.icon) || state?.attributes?.icon || "mdi:star-four-points-circle";
   }
 
   _getResolvedPicture(state) {
@@ -74363,13 +73702,7 @@ class NodaliaInsigniaCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    const tag = window.NodaliaI18n.localeTag(
-      window.NodaliaI18n.resolveLanguage(hass, this._config?.language ?? "auto"),
-    );
-    return `${tag}|${Object.entries(hass?.states || {})
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}`)
-      .sort((left, right) => left.localeCompare(right, tag, { sensitivity: "base" }))
-      .join("|")}`;
+    return window.NodaliaUtils.editorStatesSignature(hass, this._config?.language ?? "auto");
   }
 
   _watchEditorControlTag(tagName) {
@@ -74484,7 +73817,7 @@ class NodaliaInsigniaCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -74719,91 +74052,25 @@ class NodaliaInsigniaCardEditor extends HTMLElement {
   }
 
   _mountEntityPicker(host) {
-    if (!(host instanceof HTMLElement)) {
-      return;
-    }
-
-    const field = host.dataset.field || "entity";
-    const nextValue = host.dataset.value || "";
-    let control = null;
-
-    if (customElements.get("ha-entity-picker")) {
-      control = document.createElement("ha-entity-picker");
-      control.allowCustomEntity = true;
-    } else if (customElements.get("ha-selector")) {
-      control = document.createElement("ha-selector");
-      control.selector = {
-        entity: {},
-      };
-    } else {
-      control = document.createElement("input");
-      control.type = "text";
-      control.dataset.field = field;
-      control.value = nextValue;
-      control.addEventListener("change", this._onShadowInput);
-    }
-
-    control.dataset.field = field;
-    control.dataset.value = nextValue;
-
-    if ("hass" in control) {
-      control.hass = this._hass;
-    }
-
-    if ("value" in control) {
-      control.value = nextValue;
-    }
-
-    if (control.tagName !== "INPUT") {
-      control.addEventListener("value-changed", this._onShadowValueChanged);
-    }
-
-    host.replaceChildren(control);
-  }
-
-  _copyDatasetToControl(host, control) {
-    Object.entries(host.dataset || {}).forEach(([key, value]) => {
-      if (key === "mountedControl" || key === "value" || key === "placeholder") {
-        return;
-      }
-      control.dataset[key] = value;
+    window.NodaliaUtils.mountEntityPickerHost(host, {
+      hass: this._hass,
+      field: host.dataset.field || "entity",
+      value: host.dataset.value || "",
+      onShadowInput: this._onShadowInput,
+      onShadowValueChanged: this._onShadowValueChanged,
+      copyDatasetFromHost: true,
     });
   }
 
   _mountIconPicker(host) {
-    if (!(host instanceof HTMLElement)) {
-      return;
-    }
-
-    const nextValue = host.dataset.value || "";
-    const placeholder = host.dataset.placeholder || "";
-    let control = null;
-
-    if (customElements.get("ha-icon-picker")) {
-      control = document.createElement("ha-icon-picker");
-    } else {
-      control = document.createElement("input");
-      control.type = "text";
-    }
-
-    this._copyDatasetToControl(host, control);
-
-    if ("hass" in control) {
-      control.hass = this._hass;
-    }
-    if (placeholder && "placeholder" in control) {
-      control.placeholder = placeholder;
-    }
-    if ("value" in control) {
-      control.value = nextValue;
-    }
-    if (control.tagName !== "INPUT") {
-      control.addEventListener("value-changed", this._onShadowValueChanged);
-    } else {
-      control.addEventListener("change", this._onShadowInput);
-    }
-
-    host.replaceChildren(control);
+    window.NodaliaUtils.mountIconPickerHost(host, {
+      hass: this._hass,
+      value: host.dataset.value || "",
+      placeholder: host.dataset.placeholder || "",
+      onShadowInput: this._onShadowInput,
+      onShadowValueChanged: this._onShadowValueChanged,
+      copyDatasetFromHost: true,
+    });
   }
 
   _render() {
@@ -75074,6 +74341,21 @@ class NodaliaInsigniaCardEditor extends HTMLElement {
               placeholder: "mdi:star-four-points-circle",
               fullWidth: true,
             })}
+            ${this._renderIconPickerField("Icono (estado activo)", "icon_active", config.icon_active, {
+              placeholder: "mdi:door-open",
+              fullWidth: true,
+            })}
+            ${this._renderIconPickerField("Icono (estado inactivo)", "icon_inactive", config.icon_inactive, {
+              placeholder: "mdi:door-closed",
+              fullWidth: true,
+            })}
+            <div class="editor-section__hint editor-field--full" style="grid-column: 1 / -1; margin-top: -4px;">
+              ${escapeHtml(
+                this._editorLabel(
+                  "Opcional: icono distinto cuando la insignia está activa o inactiva (interruptores, puertas, ventanas, etc.). Si uno queda vacío, se usa el icono general o el de la entidad.",
+                ),
+              )}
+            </div>
             ${this._renderTextField("Nombre visible", "name", config.name, {
               placeholder: this._editorLabel("Temperatura"),
               fullWidth: true,
@@ -75405,71 +74687,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -76586,11 +75803,12 @@ class NodaliaPersonCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("person.") || entityId.startsWith("device_tracker."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(
+      hass,
+      this._config?.language,
+      id =>
+        id.startsWith("person.") || id.startsWith("device_tracker."),
+    );
   }
 
   _watchEditorControlTag(tagName) {
@@ -76740,7 +75958,7 @@ class NodaliaPersonCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -77629,71 +76847,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -80579,11 +79732,12 @@ class NodaliaWeatherCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("weather.") || entityId.startsWith("binary_sensor."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(
+      hass,
+      this._config?.language,
+      id =>
+        id.startsWith("weather.") || id.startsWith("binary_sensor."),
+    );
   }
 
   _watchEditorControlTag(tagName) {
@@ -80730,7 +79884,7 @@ class NodaliaWeatherCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -81731,71 +80885,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -84760,15 +83849,12 @@ class NodaliaVacuumCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => (
-        entityId.startsWith("vacuum.")
-        || entityId.startsWith("select.")
-        || entityId.startsWith("sensor.")
-      ))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(
+      hass,
+      this._config?.language,
+      id =>
+        id.startsWith("vacuum.") || id.startsWith("select.") || id.startsWith("sensor."),
+    );
   }
 
   _buildEntityOptions(filterFn, currentValue = "") {
@@ -84901,7 +83987,7 @@ class NodaliaVacuumCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -85938,4 +85024,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.4.0","contentSha256_12":"035cef7c0f93"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.1","contentSha256_12":"9b248096f92c"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -72695,7 +72695,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.8";
+const CARD_VERSION = "0.2.9";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -73579,8 +73579,8 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         :host([data-icon-only]) {
-          /* Same cross-axis behavior as non–icon-only pills (`align-items: center` on row).
-             `stretch` forced full line height and skewed vertical center vs text pills + menu. */
+          /* Same cross-axis behavior as non–icon-only pills (align-items: center on row).
+             stretch forced full line height and skewed vertical center vs text pills + menu. */
           align-self: var(--insignia-icon-only-align-self, center);
           box-sizing: border-box;
           display: flex;
@@ -85193,4 +85193,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.7","contentSha256_12":"1a62cc42d7c6"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.8","contentSha256_12":"a25ebaa76762"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -42275,7 +42275,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.19";
+const CARD_VERSION = "0.12.20";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -44394,10 +44394,13 @@ class NodaliaGraphCard extends HTMLElement {
         }
 
         .graph-card__hover-points-layer {
-          inset: 0;
+          bottom: 12px;
+          left: 0;
           overflow: hidden;
           pointer-events: none;
           position: absolute;
+          right: 0;
+          top: 4px;
           z-index: 2;
         }
 
@@ -44452,11 +44455,13 @@ class NodaliaGraphCard extends HTMLElement {
           -webkit-backdrop-filter: blur(14px);
           backdrop-filter: blur(14px);
           background:
-            linear-gradient(180deg, color-mix(in srgb, var(--tooltip-tint) 18%, rgba(255,255,255,0.09)), rgba(255,255,255,0.025)),
-            color-mix(in srgb, var(--ha-card-background, var(--card-background-color, #fff)) 86%, transparent);
-          border: 1px solid color-mix(in srgb, var(--tooltip-tint) 34%, color-mix(in srgb, var(--primary-text-color) 9%, transparent));
+            linear-gradient(180deg, color-mix(in srgb, var(--tooltip-tint) 20%, rgba(255,255,255,0.1)), rgba(255,255,255,0.02)),
+            color-mix(in srgb, var(--ha-card-background, var(--card-background-color, #fff)) 94%, rgba(255,255,255,0.02));
+          border: 1px solid color-mix(in srgb, var(--tooltip-tint) 22%, color-mix(in srgb, var(--primary-text-color) 10%, transparent));
           border-radius: 16px;
-          box-shadow: 0 16px 34px rgba(0, 0, 0, 0.28);
+          box-shadow:
+            0 10px 24px rgba(0, 0, 0, 0.24),
+            0 2px 6px color-mix(in srgb, var(--tooltip-tint) 14%, transparent);
           color: var(--primary-text-color);
           display: grid;
           gap: 8px;
@@ -44468,6 +44473,21 @@ class NodaliaGraphCard extends HTMLElement {
           transform: var(--graph-tooltip-transform, translate(-50%, -100%));
           will-change: left, top, transform;
           z-index: 2147483001;
+        }
+
+        .graph-card__tooltip::before {
+          content: "";
+          position: absolute;
+          inset: 0;
+          border-radius: inherit;
+          pointer-events: none;
+          background:
+            linear-gradient(180deg, color-mix(in srgb, var(--tooltip-tint) 18%, rgba(255,255,255,0.09)), rgba(255,255,255,0.025)),
+            color-mix(in srgb, var(--ha-card-background, var(--card-background-color, #fff)) 90%, transparent);
+          box-shadow:
+            inset 0 1px 0 color-mix(in srgb, var(--primary-text-color) 16%, transparent),
+            inset 0 -1px 0 rgba(0, 0, 0, 0.06);
+          z-index: -1;
         }
 
         .graph-card__tooltip--entering {
@@ -85163,4 +85183,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.11","contentSha256_12":"294512605e1c"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.12","contentSha256_12":"68e4cc452084"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -42221,7 +42221,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.14";
+const CARD_VERSION = "0.12.15";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -44300,7 +44300,7 @@ class NodaliaGraphCard extends HTMLElement {
           border-radius: ${styles.card.border_radius};
           box-shadow: inset 0 1px 0 color-mix(in srgb, var(--primary-text-color) 5%, transparent);
           flex: 1 1 auto;
-          margin: 6px -${chartBleedRight}px -${chartBleedBottom}px -${chartBleedLeft}px;
+          margin: 14px -${chartBleedRight}px -${chartBleedBottom}px -${chartBleedLeft}px;
           max-width: none;
           min-height: ${chartHeight};
           min-width: 0;
@@ -72618,7 +72618,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.2";
+const CARD_VERSION = "0.2.3";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -73484,7 +73484,7 @@ class NodaliaInsigniaCard extends HTMLElement {
     const iconOnly = !showName && !showValue;
     const iconOnlySize = Math.max(36, Math.min(iconSizePx + 12, 46));
     const iconOnlyIconBase = parseSizeToPixels(styles.icon?.size, iconSizePx);
-    const iconOnlyIconSize = Math.max(18, Math.min(Math.round(iconOnlyIconBase), iconOnlySize - 8));
+    const iconOnlyIconSize = Math.max(18, Math.min(Math.round(iconOnlyIconBase), iconOnlySize - 12));
     const iconOnlyOffsetY = String(styles.icon?.icon_only_offset_y ?? DEFAULT_CONFIG.styles.icon.icon_only_offset_y);
     const pictureUrl = this._getResolvedPicture(state);
     const showPicture = Boolean(pictureUrl);
@@ -73579,10 +73579,11 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         .insignia-card--icon-only .insignia-card__content {
           align-items: center;
+          box-sizing: border-box;
           display: grid;
           place-items: center;
           margin: 0;
-          padding: 0;
+          padding: 3px;
           grid-template-columns: 1fr;
           width: 100%;
           height: 100%;
@@ -73639,12 +73640,13 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         .insignia-card--icon-only .insignia-card__icon ha-icon {
           --mdc-icon-size: var(--icon-only-icon-size);
-          height: var(--icon-only-icon-size);
-          width: var(--icon-only-icon-size);
-          line-height: var(--icon-only-icon-size);
           display: flex;
           align-items: center;
           justify-content: center;
+          height: var(--icon-only-icon-size);
+          width: var(--icon-only-icon-size);
+          line-height: 0;
+          overflow: visible;
           position: relative;
           top: var(--icon-only-offset-y);
           transform: translateY(0) !important;
@@ -85097,4 +85099,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.2","contentSha256_12":"6a995829c98d"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.3","contentSha256_12":"78f0762fc1b1"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -72695,7 +72695,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.6";
+const CARD_VERSION = "0.2.8";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -73579,7 +73579,9 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         :host([data-icon-only]) {
-          align-self: stretch;
+          /* Same cross-axis behavior as non–icon-only pills (`align-items: center` on row).
+             `stretch` forced full line height and skewed vertical center vs text pills + menu. */
+          align-self: var(--insignia-icon-only-align-self, center);
           box-sizing: border-box;
           display: flex;
           align-items: center;
@@ -85191,4 +85193,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.6","contentSha256_12":"70136d5d2f52"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.7","contentSha256_12":"1a62cc42d7c6"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -72702,7 +72702,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.10";
+const CARD_VERSION = "0.2.11";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -72891,6 +72891,29 @@ function deleteByPath(target, path) {
 function parseSizeToPixels(value, fallback = 0) {
   const numeric = Number.parseFloat(String(value ?? ""));
   return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+/** Sum of top + bottom padding from CSS shorthand (px numbers). */
+function parsePaddingVertical(padding, fallback = 8) {
+  const raw = String(padding ?? "").trim();
+  if (!raw) {
+    return fallback;
+  }
+  const tokens = raw.split(/\s+/).filter(Boolean);
+  const px = tokens.map(token => parseSizeToPixels(token, Number.NaN)).filter(n => Number.isFinite(n));
+  if (!px.length) {
+    return fallback;
+  }
+  if (px.length === 1) {
+    return px[0] * 2;
+  }
+  if (px.length === 2) {
+    return px[0] * 2;
+  }
+  if (px.length === 3) {
+    return px[0] + px[2];
+  }
+  return px[0] + px[2];
 }
 
 function normalizeTextKey(value) {
@@ -73567,9 +73590,16 @@ class NodaliaInsigniaCard extends HTMLElement {
     const showName = config.show_name !== false;
     const showValue = config.show_value !== false && Boolean(value);
     const iconOnly = !showName && !showValue;
-    const iconOnlySize = Math.max(36, Math.min(iconSizePx + 12, 46));
-    const iconOnlyIconBase = parseSizeToPixels(styles.icon?.size, iconSizePx);
-    const iconOnlyIconSize = Math.max(18, Math.min(Math.round(iconOnlyIconBase), iconOnlySize - 12));
+    const cardPaddingVertical = parsePaddingVertical(
+      styles.card?.padding ?? DEFAULT_CONFIG.styles.card.padding,
+      8,
+    );
+    // Outer square matches pill height: vertical padding + icon disc (same as non–icon-only row).
+    const iconOnlySize = cardPaddingVertical + iconSizePx;
+    const iconOnlyContentInset = 6;
+    const iconOnlyInner = Math.max(0, iconOnlySize - iconOnlyContentInset);
+    const iconGlyphDefault = Math.round(iconSizePx * 0.5);
+    const iconOnlyIconSize = Math.max(16, Math.min(iconGlyphDefault, iconOnlyInner));
     const iconOnlyOffsetY = String(styles.icon?.icon_only_offset_y ?? DEFAULT_CONFIG.styles.icon.icon_only_offset_y);
     const pictureUrl = this._getResolvedPicture(state);
     const showPicture = Boolean(pictureUrl);
@@ -73597,9 +73627,10 @@ class NodaliaInsigniaCard extends HTMLElement {
           width: auto;
           min-height: min-content;
           transform: translateY(var(--insignia-icon-only-row-nudge, -2px));
+          /* Default 0 so icon-only height matches the text pill; use vars in horizontal scroll strips. */
           padding-block: var(
             --insignia-scroll-strip-padding-block,
-            var(--insignia-scroll-strip-margin-block, 4px)
+            var(--insignia-scroll-strip-margin-block, 0px)
           );
         }
 
@@ -85202,4 +85233,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.9","contentSha256_12":"12d89e29e7bd"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.10","contentSha256_12":"e559c97721fd"};}

--- a/nodalia-cards.js
+++ b/nodalia-cards.js
@@ -14714,19 +14714,6 @@
   }
 
   /**
-   * Cheap signature when the editor only needs to know if hass/stale registry size changed.
-   * Includes locale tag so language switches still re-render translated labels.
-   */
-  function editorStatesSignature(hass, language) {
-    const count = Object.keys(hass?.states || {}).length;
-    const tag =
-      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
-        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
-        : "";
-    return `${tag}|${count}`;
-  }
-
-  /**
    * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
    * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
    */
@@ -14752,6 +14739,15 @@
         ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
         : "";
     return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -42279,7 +42275,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.18";
+const CARD_VERSION = "0.12.19";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -44739,22 +44735,33 @@ class NodaliaGraphCard extends HTMLElement {
             gap: 8px;
           }
 
-          .graph-card__legend {
-            justify-content: flex-start;
-          }
-
+          /* Keep value + legend chips on one row; scroll chips horizontally if needed
+             (wrapping pushed the chart up and overlapped the plot). */
           .graph-card__primary-row {
-            flex-wrap: wrap;
-            row-gap: 6px;
+            flex-wrap: nowrap;
+            gap: 8px 10px;
           }
 
           .graph-card__primary-row .graph-card__value {
-            flex: 1 1 auto;
+            flex: 0 1 auto;
+            min-width: 0;
           }
 
           .graph-card__primary-row .graph-card__legend {
-            flex: 1 1 100%;
-            justify-content: flex-start;
+            flex: 1 1 0;
+            flex-wrap: nowrap;
+            justify-content: flex-end;
+            margin-bottom: 0;
+            min-width: 0;
+            overflow-x: auto;
+            overscroll-behavior-x: contain;
+            scrollbar-width: thin;
+            -webkit-overflow-scrolling: touch;
+          }
+
+          .graph-card__primary-row .graph-card__legend-item {
+            flex-shrink: 0;
+            max-width: min(52vw, 160px);
           }
         }
       </style>
@@ -72695,7 +72702,7 @@ window.customCards.push({
 {
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.9";
+const CARD_VERSION = "0.2.10";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -73620,7 +73627,7 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         .insignia-card--icon-only {
-          border-radius: 999px;
+          border-radius: ${styles.card.border_radius};
           display: flex;
           align-items: center;
           justify-content: center;
@@ -73669,6 +73676,7 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         .insignia-card--icon-only .insignia-card__content {
           align-items: center;
+          border-radius: inherit;
           box-sizing: border-box;
           display: grid;
           place-items: center;
@@ -73699,6 +73707,7 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         .insignia-card--icon-only .insignia-card__icon {
           align-self: center;
+          border-radius: inherit;
           justify-self: center;
           display: flex;
           align-items: center;
@@ -73716,7 +73725,7 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         .insignia-card__icon img {
-          border-radius: 999px;
+          border-radius: inherit;
           height: 100%;
           object-fit: cover;
           width: 100%;
@@ -85193,4 +85202,4 @@ window.customCards.push({
 
 }
 
-;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.8","contentSha256_12":"a25ebaa76762"};}
+;if(typeof window!=="undefined"){window.__NODALIA_BUNDLE__={"pkgVersion":"0.5.0-alpha.9","contentSha256_12":"12d89e29e7bd"};}

--- a/nodalia-circular-gauge-card.js
+++ b/nodalia-circular-gauge-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-circular-gauge-card.js
+++ b/nodalia-circular-gauge-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-circular-gauge-card";
 const EDITOR_TAG = "nodalia-circular-gauge-card-editor";
 const CARD_VERSION = "0.12.1";

--- a/nodalia-circular-gauge-card.js
+++ b/nodalia-circular-gauge-card.js
@@ -203,71 +203,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -1956,15 +1891,9 @@ class NodaliaCircularGaugeCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => (
-        entityId.startsWith("sensor.")
-        || entityId.startsWith("number.")
-        || entityId.startsWith("input_number.")
-      ))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id =>
+      id.startsWith("sensor.") || id.startsWith("number.") || id.startsWith("input_number."),
+    );
   }
 
   _getNumericEntityOptions() {
@@ -2080,7 +2009,7 @@ class NodaliaCircularGaugeCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-circular-gauge-card.js
+++ b/nodalia-circular-gauge-card.js
@@ -653,6 +653,57 @@ function escapeSelectorValue(value) {
   return String(value ?? "").replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
+function sanitizeCssValue(value, fallback) {
+  const raw = String(value ?? "").trim();
+  const safeFallback = String(fallback ?? "").trim();
+  if (!raw) {
+    return safeFallback;
+  }
+  if (/[\u0000-\u001f\u007f<>;"'{}]/.test(raw) || raw.includes("/*") || raw.includes("*/")) {
+    return safeFallback;
+  }
+  return raw;
+}
+
+function getSafeStyles(styles = DEFAULT_CONFIG.styles) {
+  const defaults = DEFAULT_CONFIG.styles;
+  const card = styles?.card || {};
+  const icon = styles?.icon || {};
+  const gauge = styles?.gauge || {};
+  return {
+    card: {
+      background: sanitizeCssValue(card.background, defaults.card.background),
+      border: sanitizeCssValue(card.border, defaults.card.border),
+      border_radius: sanitizeCssValue(card.border_radius, defaults.card.border_radius),
+      box_shadow: sanitizeCssValue(card.box_shadow, defaults.card.box_shadow),
+      padding: sanitizeCssValue(card.padding, defaults.card.padding),
+      gap: sanitizeCssValue(card.gap, defaults.card.gap),
+    },
+    icon: {
+      size: sanitizeCssValue(icon.size, defaults.icon.size),
+      background: sanitizeCssValue(icon.background, defaults.icon.background),
+      color: sanitizeCssValue(icon.color, defaults.icon.color),
+    },
+    chip_height: sanitizeCssValue(styles?.chip_height, defaults.chip_height),
+    chip_font_size: sanitizeCssValue(styles?.chip_font_size, defaults.chip_font_size),
+    chip_padding: sanitizeCssValue(styles?.chip_padding, defaults.chip_padding),
+    title_size: sanitizeCssValue(styles?.title_size, defaults.title_size),
+    value_size: sanitizeCssValue(styles?.value_size, defaults.value_size),
+    range_size: sanitizeCssValue(styles?.range_size, defaults.range_size),
+    name_chip_max_width: sanitizeCssValue(styles?.name_chip_max_width, defaults.name_chip_max_width),
+    gauge: {
+      size: sanitizeCssValue(gauge.size, defaults.gauge.size),
+      stroke: sanitizeCssValue(gauge.stroke, defaults.gauge.stroke),
+      thumb_size: sanitizeCssValue(gauge.thumb_size, defaults.gauge.thumb_size),
+      track_color: sanitizeCssValue(gauge.track_color, defaults.gauge.track_color),
+      background: sanitizeCssValue(gauge.background, defaults.gauge.background),
+      min_tint_color: sanitizeCssValue(gauge.min_tint_color, defaults.gauge.min_tint_color),
+      max_tint_color: sanitizeCssValue(gauge.max_tint_color, defaults.gauge.max_tint_color),
+      foreground_color: sanitizeCssValue(gauge.foreground_color, defaults.gauge.foreground_color),
+    },
+  };
+}
+
 function resolveEditorColorValue(value) {
   const rawValue = String(value ?? "").trim();
   if (!rawValue || typeof document === "undefined") {
@@ -1439,7 +1490,7 @@ class NodaliaCircularGaugeCard extends HTMLElement {
     }
 
     const config = this._config || normalizeConfig({});
-    const styles = config.styles || DEFAULT_CONFIG.styles;
+    const styles = getSafeStyles(config.styles);
     const state = this._getState();
 
     if (!state) {
@@ -1460,7 +1511,8 @@ class NodaliaCircularGaugeCard extends HTMLElement {
     const dialAngle = DIAL_START_ANGLE + (ratio * DIAL_SWEEP);
     const thumbPosition = getDialMarkerPosition(dialAngle);
     const dialStartCoordinates = getDialMarkerCoordinates(DIAL_START_ANGLE);
-    const dialStartCapColor = String(styles.gauge.foreground_color || "").trim() || resolveGaugeTintColor(tintScale, 0.02);
+    const dialStartCapColor =
+      sanitizeCssValue(styles.gauge.foreground_color, "") || resolveGaugeTintColor(tintScale, 0.02);
     const showUnavailableBadge = config.show_unavailable_badge !== false && isUnavailableState(state);
     const showHeader = config.show_header !== false;
     const showName = config.show_name !== false;
@@ -2106,7 +2158,7 @@ class NodaliaCircularGaugeCard extends HTMLElement {
                       cx="${DIAL_VIEWBOX_SIZE / 2}"
                       cy="${DIAL_VIEWBOX_SIZE / 2}"
                       r="${DIAL_CIRCLE_RADIUS}"
-                      style="stroke:${segment.color};stroke-dasharray:${segment.dasharray};stroke-dashoffset:${segment.dashoffset};opacity:${segment.opacity};"
+                      style="stroke:${sanitizeCssValue(segment.color, styles.gauge.max_tint_color)};stroke-dasharray:${segment.dasharray};stroke-dashoffset:${segment.dashoffset};opacity:${segment.opacity};"
                     ></circle>
                   `)
                   .join("")}
@@ -2116,7 +2168,7 @@ class NodaliaCircularGaugeCard extends HTMLElement {
                   cx="${dialStartCoordinates.x}"
                   cy="${dialStartCoordinates.y}"
                   r="${Number((dialStrokePx / 2).toFixed(3))}"
-                  style="fill:${dialStartCapColor};"
+                  style="fill:${sanitizeCssValue(dialStartCapColor, styles.gauge.max_tint_color)};"
                 ></circle>
               </svg>
               <span class="gauge-card__dial-thumb" aria-hidden="true"></span>

--- a/nodalia-climate-card.js
+++ b/nodalia-climate-card.js
@@ -191,71 +191,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -2750,10 +2685,7 @@ class NodaliaClimateCardEditorLegacy extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.keys(hass?.states || {})
-      .filter(entityId => entityId.startsWith("climate."))
-      .sort((left, right) => left.localeCompare(right, "es"))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id => id.startsWith("climate."));
   }
 
   _captureFocusState() {
@@ -2836,7 +2768,7 @@ class NodaliaClimateCardEditorLegacy extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -3328,11 +3260,7 @@ class NodaliaClimateCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("climate."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id => id.startsWith("climate."));
   }
 
   _getClimateEntityOptions() {
@@ -3445,7 +3373,7 @@ class NodaliaClimateCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-climate-card.js
+++ b/nodalia-climate-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-climate-card.js
+++ b/nodalia-climate-card.js
@@ -983,6 +983,8 @@ class NodaliaClimateCard extends HTMLElement {
     this._temperatureCommitInFlight = false;
     this._temperatureCommitRetryCount = 0;
     this._activeDialDrag = null;
+    this._dialDragFrame = 0;
+    this._pendingDialDragPoint = null;
     this._pendingRenderAfterDrag = false;
     this._lastRenderSignature = "";
     this._animateContentOnNextRender = true;
@@ -1051,6 +1053,11 @@ class NodaliaClimateCard extends HTMLElement {
       window.clearTimeout(this._entranceAnimationResetTimer);
       this._entranceAnimationResetTimer = 0;
     }
+    if (this._dialDragFrame) {
+      window.cancelAnimationFrame(this._dialDragFrame);
+      this._dialDragFrame = 0;
+    }
+    this._pendingDialDragPoint = null;
     this._animateContentOnNextRender = true;
     this._lastRenderSignature = "";
   }
@@ -1774,6 +1781,22 @@ class NodaliaClimateCard extends HTMLElement {
     this._applyDialValue(nextValue, { commit: false });
   }
 
+  _queueDialDragMove(clientX, clientY, event = null) {
+    this._pendingDialDragPoint = { clientX, clientY, event };
+    if (this._dialDragFrame) {
+      return;
+    }
+    this._dialDragFrame = window.requestAnimationFrame(() => {
+      this._dialDragFrame = 0;
+      const pending = this._pendingDialDragPoint;
+      this._pendingDialDragPoint = null;
+      if (!pending) {
+        return;
+      }
+      this._moveDialDrag(pending.clientX, pending.clientY, pending.event);
+    });
+  }
+
   _commitDialDrag(clientX, clientY, event = null, pointerId = null) {
     const drag = this._activeDialDrag;
     const state = this._getState();
@@ -1785,6 +1808,11 @@ class NodaliaClimateCard extends HTMLElement {
     if (event) {
       event.preventDefault();
     }
+    if (this._dialDragFrame) {
+      window.cancelAnimationFrame(this._dialDragFrame);
+      this._dialDragFrame = 0;
+    }
+    this._pendingDialDragPoint = null;
 
     const nextValue = getDialValueFromPoint(
       drag.dial,
@@ -1879,7 +1907,7 @@ class NodaliaClimateCard extends HTMLElement {
       return;
     }
 
-    this._moveDialDrag(event.clientX, event.clientY, event);
+    this._queueDialDragMove(event.clientX, event.clientY, event);
   }
 
   _onWindowPointerUp(event) {
@@ -1896,7 +1924,7 @@ class NodaliaClimateCard extends HTMLElement {
       return;
     }
 
-    this._moveDialDrag(event.clientX, event.clientY, event);
+    this._queueDialDragMove(event.clientX, event.clientY, event);
   }
 
   _onWindowMouseUp(event) {
@@ -1912,7 +1940,7 @@ class NodaliaClimateCard extends HTMLElement {
       return;
     }
 
-    this._moveDialDrag(event.touches[0].clientX, event.touches[0].clientY, event);
+    this._queueDialDragMove(event.touches[0].clientX, event.touches[0].clientY, event);
   }
 
   _onWindowTouchStartCapture(event) {

--- a/nodalia-climate-card.js
+++ b/nodalia-climate-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-climate-card";
 const EDITOR_TAG = "nodalia-climate-card-editor";
 const CARD_VERSION = "0.10.5";

--- a/nodalia-editor-ui.js
+++ b/nodalia-editor-ui.js
@@ -6399,6 +6399,227 @@
     "ro": "Vizibilitate"
   },
   {
+    "es": "Insignia",
+    "en": "Insignia",
+    "de": "Insignia",
+    "fr": "Insignia",
+    "it": "Insignia",
+    "nl": "Insignia",
+    "pt": "Insignia",
+    "ru": "Insignia",
+    "el": "Insignia",
+    "zh": "Insignia",
+    "ro": "Insignia"
+  },
+  {
+    "es": "Chip compacto para la barra de insignias: entidad, icono y texto opcionales.",
+    "en": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "de": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "fr": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "it": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "nl": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "pt": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "ru": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "el": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "zh": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales.",
+    "ro": "Chip compacto para la barra de insignias: Entity, Icon y texto opcionales."
+  },
+  {
+    "es": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "en": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "de": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "fr": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "it": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "nl": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "pt": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "ru": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "el": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "zh": "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+    "ro": "Vibración al pulsar la insignia (si el dispositivo lo permite)."
+  },
+  {
+    "es": "Acción al pulsar",
+    "en": "Acción al pulsar",
+    "de": "Acción al pulsar",
+    "fr": "Acción al pulsar",
+    "it": "Acción al pulsar",
+    "nl": "Acción al pulsar",
+    "pt": "Acción al pulsar",
+    "ru": "Acción al pulsar",
+    "el": "Acción al pulsar",
+    "zh": "Acción al pulsar",
+    "ro": "Acción al pulsar"
+  },
+  {
+    "es": "Qué ocurre al tocar la insignia.",
+    "en": "Qué ocurre al tocar la insignia.",
+    "de": "Qué ocurre al tocar la insignia.",
+    "fr": "Qué ocurre al tocar la insignia.",
+    "it": "Qué ocurre al tocar la insignia.",
+    "nl": "Qué ocurre al tocar la insignia.",
+    "pt": "Qué ocurre al tocar la insignia.",
+    "ru": "Qué ocurre al tocar la insignia.",
+    "el": "Qué ocurre al tocar la insignia.",
+    "zh": "Qué ocurre al tocar la insignia.",
+    "ro": "Qué ocurre al tocar la insignia."
+  },
+  {
+    "es": "Apariencia",
+    "en": "Apariencia",
+    "de": "Apariencia",
+    "fr": "Apariencia",
+    "it": "Apariencia",
+    "nl": "Apariencia",
+    "pt": "Apariencia",
+    "ru": "Apariencia",
+    "el": "Apariencia",
+    "zh": "Apariencia",
+    "ro": "Apariencia"
+  },
+  {
+    "es": "Tamaños, colores del icono y tinte de la burbuja.",
+    "en": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "de": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "fr": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "it": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "nl": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "pt": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "ru": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "el": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "zh": "Tamaños, Colores del Icon y Tint de la burbuja.",
+    "ro": "Tamaños, Colores del Icon y Tint de la burbuja."
+  },
+  {
+    "es": "Mostrar detalles de estilo",
+    "en": "Mostrar detalles de Style",
+    "de": "Mostrar detalles de Style",
+    "fr": "Mostrar detalles de Style",
+    "it": "Mostrar detalles de Style",
+    "nl": "Mostrar detalles de Style",
+    "pt": "Mostrar detalles de Style",
+    "ru": "Mostrar detalles de Style",
+    "el": "Mostrar detalles de Style",
+    "zh": "Mostrar detalles de Style",
+    "ro": "Mostrar detalles de Style"
+  },
+  {
+    "es": "Ocultar detalles de estilo",
+    "en": "Ocultar detalles de Style",
+    "de": "Ocultar detalles de Style",
+    "fr": "Ocultar detalles de Style",
+    "it": "Ocultar detalles de Style",
+    "nl": "Ocultar detalles de Style",
+    "pt": "Ocultar detalles de Style",
+    "ru": "Ocultar detalles de Style",
+    "el": "Ocultar detalles de Style",
+    "zh": "Ocultar detalles de Style",
+    "ro": "Ocultar detalles de Style"
+  },
+  {
+    "es": "Subtitulo",
+    "en": "SubTitle",
+    "de": "SubTitle",
+    "fr": "SubTitle",
+    "it": "SubTitle",
+    "nl": "SubTitle",
+    "pt": "SubTitle",
+    "ru": "SubTitle",
+    "el": "SubTitle",
+    "zh": "SubTitle",
+    "ro": "SubTitle"
+  },
+  {
+    "es": "Subtítulo",
+    "en": "Subtítulo",
+    "de": "Subtítulo",
+    "fr": "Subtítulo",
+    "it": "Subtítulo",
+    "nl": "Subtítulo",
+    "pt": "Subtítulo",
+    "ru": "Subtítulo",
+    "el": "Subtítulo",
+    "zh": "Subtítulo",
+    "ro": "Subtítulo"
+  },
+  {
+    "es": "Posicion",
+    "en": "Posicion",
+    "de": "Posicion",
+    "fr": "Posicion",
+    "it": "Posicion",
+    "nl": "Posicion",
+    "pt": "Posicion",
+    "ru": "Posicion",
+    "el": "Posicion",
+    "zh": "Posicion",
+    "ro": "Posicion"
+  },
+  {
+    "es": "Posición",
+    "en": "Posición",
+    "de": "Posición",
+    "fr": "Posición",
+    "it": "Posición",
+    "nl": "Posición",
+    "pt": "Posición",
+    "ru": "Posición",
+    "el": "Posición",
+    "zh": "Posición",
+    "ro": "Posición"
+  },
+  {
+    "es": "Reproductor",
+    "en": "Player",
+    "de": "Player",
+    "fr": "Player",
+    "it": "Player",
+    "nl": "Player",
+    "pt": "Player",
+    "ru": "Player",
+    "el": "Player",
+    "zh": "Player",
+    "ro": "Player"
+  },
+  {
+    "es": "Principal",
+    "en": "Main",
+    "de": "Main",
+    "fr": "Main",
+    "it": "Main",
+    "nl": "Main",
+    "pt": "Main",
+    "ru": "Main",
+    "el": "Main",
+    "zh": "Main",
+    "ro": "Main"
+  },
+  {
+    "es": "Mostrar ajustes de animacion",
+    "en": "Mostrar ajustes de animacion",
+    "de": "Mostrar ajustes de animacion",
+    "fr": "Mostrar ajustes de animacion",
+    "it": "Mostrar ajustes de animacion",
+    "nl": "Mostrar ajustes de animacion",
+    "pt": "Mostrar ajustes de animacion",
+    "ru": "Mostrar ajustes de animacion",
+    "el": "Mostrar ajustes de animacion",
+    "zh": "Mostrar ajustes de animacion",
+    "ro": "Mostrar ajustes de animacion"
+  },
+  {
+    "es": "Ocultar ajustes de animacion",
+    "en": "Ocultar ajustes de animacion",
+    "de": "Ocultar ajustes de animacion",
+    "fr": "Ocultar ajustes de animacion",
+    "it": "Ocultar ajustes de animacion",
+    "nl": "Ocultar ajustes de animacion",
+    "pt": "Ocultar ajustes de animacion",
+    "ru": "Ocultar ajustes de animacion",
+    "el": "Ocultar ajustes de animacion",
+    "zh": "Ocultar ajustes de animacion",
+    "ro": "Ocultar ajustes de animacion"
+  },
+  {
     "es": "Anadir ruta",
     "en": "Add route",
     "de": "Add route",
@@ -9137,7 +9358,7 @@
     substitutions.forEach(([pattern, replacement]) => {
       out = out.replace(pattern, (match, ...rest) => {
         const groups = rest.slice(0, -2);
-        const expanded = String(replacement).replace(/$(d+)/g, (_, groupIndexRaw) => {
+        const expanded = String(replacement).replace(/\$(\d+)/g, (_, groupIndexRaw) => {
           const groupIndex = Number(groupIndexRaw) - 1;
           return groups[groupIndex] ?? "";
         });
@@ -9146,7 +9367,7 @@
     });
 
     // Clean up legacy literal replacement artifacts left by earlier generator versions.
-    out = out.replace(/$(d+)/g, "");
+    out = out.replace(/\$(\d+)/g, "");
 
     return out;
   }

--- a/nodalia-editor-ui.js
+++ b/nodalia-editor-ui.js
@@ -9135,7 +9135,14 @@
     ];
 
     substitutions.forEach(([pattern, replacement]) => {
-      out = out.replace(pattern, match => withMatchCase(match, replacement));
+      out = out.replace(pattern, (match, ...rest) => {
+        const groups = rest.slice(0, -2);
+        const expanded = String(replacement).replace(/$(d+)/g, (_, groupIndexRaw) => {
+          const groupIndex = Number(groupIndexRaw) - 1;
+          return groups[groupIndex] ?? "";
+        });
+        return withMatchCase(match, expanded);
+      });
     });
 
     return out;

--- a/nodalia-editor-ui.js
+++ b/nodalia-editor-ui.js
@@ -9145,6 +9145,9 @@
       });
     });
 
+    // Clean up legacy literal replacement artifacts left by earlier generator versions.
+    out = out.replace(/$(d+)/g, "");
+
     return out;
   }
 

--- a/nodalia-entity-card.js
+++ b/nodalia-entity-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-entity-card";
 const EDITOR_TAG = "nodalia-entity-card-editor";
 const CARD_VERSION = "0.6.6";

--- a/nodalia-entity-card.js
+++ b/nodalia-entity-card.js
@@ -189,71 +189,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -1784,11 +1719,7 @@ class NodaliaEntityCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    const tag = window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, this._config?.language));
-    return `${tag}|${Object.entries(hass?.states || {})
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, tag, { sensitivity: "base" }))
-      .join("|")}`;
+    return window.NodaliaUtils.editorStatesSignature(hass, this._config?.language);
   }
 
   _watchEditorControlTag(tagName) {
@@ -1934,7 +1865,7 @@ class NodaliaEntityCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -2236,28 +2167,28 @@ class NodaliaEntityCardEditor extends HTMLElement {
       return;
     }
 
+    if (customElements.get("ha-entity-picker") || customElements.get("ha-selector")) {
+      window.NodaliaUtils.mountEntityPickerHost(host, {
+        hass: this._hass,
+        field: host.dataset.field || "entity",
+        value: host.dataset.value || "",
+        onShadowInput: this._onShadowInput,
+        onShadowValueChanged: this._onShadowValueChanged,
+        copyDatasetFromHost: true,
+      });
+      return;
+    }
+
     const field = host.dataset.field || "entity";
     const nextValue = host.dataset.value || "";
-    let control = null;
-
-    if (customElements.get("ha-entity-picker")) {
-      control = document.createElement("ha-entity-picker");
-      control.allowCustomEntity = true;
-    } else if (customElements.get("ha-selector")) {
-      control = document.createElement("ha-selector");
-      control.selector = {
-        entity: {},
-      };
-    } else {
-      control = document.createElement("select");
-      this._getEntityOptions(field).forEach(option => {
-        const optionElement = document.createElement("option");
-        optionElement.value = option.value;
-        optionElement.textContent = option.displayLabel;
-        control.appendChild(optionElement);
-      });
-      control.addEventListener("change", this._onShadowInput);
-    }
+    const control = document.createElement("select");
+    this._getEntityOptions(field).forEach(option => {
+      const optionElement = document.createElement("option");
+      optionElement.value = option.value;
+      optionElement.textContent = option.displayLabel;
+      control.appendChild(optionElement);
+    });
+    control.addEventListener("change", this._onShadowInput);
 
     control.dataset.field = field;
     control.dataset.value = nextValue;
@@ -2268,10 +2199,6 @@ class NodaliaEntityCardEditor extends HTMLElement {
 
     if ("value" in control) {
       control.value = nextValue;
-    }
-
-    if (control.tagName !== "SELECT") {
-      control.addEventListener("value-changed", this._onShadowValueChanged);
     }
 
     host.replaceChildren(control);

--- a/nodalia-entity-card.js
+++ b/nodalia-entity-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };
@@ -1253,8 +1291,34 @@ class NodaliaEntityCard extends HTMLElement {
     }
   }
 
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
   _callConfiguredService(serviceValue, entityId = this._config?.entity, rawData = "") {
     if (!this._hass || !serviceValue) {
+      return;
+    }
+
+    if (!this._isServiceAllowed(serviceValue)) {
       return;
     }
 
@@ -1272,7 +1336,7 @@ class NodaliaEntityCard extends HTMLElement {
   }
 
   _openConfiguredUrl(urlValue = this._config?.tap_url, newTab = this._config?.tap_new_tab === true) {
-    const url = String(urlValue || "").trim();
+    const url = window.NodaliaUtils?.sanitizeActionUrl(urlValue, { allowRelative: true }) || "";
     if (!url) {
       return;
     }

--- a/nodalia-fan-card.js
+++ b/nodalia-fan-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-fan-card.js
+++ b/nodalia-fan-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-fan-card";
 const EDITOR_TAG = "nodalia-fan-card-editor";
 const CARD_VERSION = "0.6.3";

--- a/nodalia-fan-card.js
+++ b/nodalia-fan-card.js
@@ -170,71 +170,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -2607,11 +2542,7 @@ class NodaliaFanCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("fan."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id => id.startsWith("fan."));
   }
 
   _getFanEntityOptions() {
@@ -2724,7 +2655,7 @@ class NodaliaFanCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-fav-card.js
+++ b/nodalia-fav-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-fav-card";
 const EDITOR_TAG = "nodalia-fav-card-editor";
 const CARD_VERSION = "0.8.2";

--- a/nodalia-fav-card.js
+++ b/nodalia-fav-card.js
@@ -174,71 +174,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -2147,10 +2082,7 @@ class NodaliaFavCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorStatesSignature(hass, this._config?.language);
   }
 
   _getEntityOptions(field = "entity", domains = []) {
@@ -2270,7 +2202,7 @@ class NodaliaFavCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-fav-card.js
+++ b/nodalia-fav-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };
@@ -1663,8 +1701,34 @@ class NodaliaFavCard extends HTMLElement {
     }
   }
 
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
   _callConfiguredService(serviceValue, entityId = this._config?.entity, rawData = "") {
     if (!this._hass || !serviceValue) {
+      return;
+    }
+
+    if (!this._isServiceAllowed(serviceValue)) {
       return;
     }
 
@@ -1682,7 +1746,7 @@ class NodaliaFavCard extends HTMLElement {
   }
 
   _openConfiguredUrl(urlValue = this._config?.tap_url, newTab = this._config?.tap_new_tab === true) {
-    const url = String(urlValue || "").trim();
+    const url = window.NodaliaUtils?.sanitizeActionUrl(urlValue, { allowRelative: true }) || "";
     if (!url) {
       return;
     }

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.12";
+const CARD_VERSION = "0.12.13";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -55,17 +55,17 @@ const DEFAULT_CONFIG = {
       border_radius: "30px",
       box_shadow: "var(--ha-card-box-shadow)",
       padding: "16px",
-      gap: "12px",
+      gap: "10px",
     },
     icon: {
       color: "var(--primary-text-color)",
       size: "28px",
     },
-    title_size: "15px",
-    value_size: "52px",
-    unit_size: "20px",
-    legend_size: "13px",
-    chart_height: "170px",
+    title_size: "13px",
+    value_size: "40px",
+    unit_size: "17px",
+    legend_size: "11px",
+    chart_height: "178px",
     line_width: "1px",
   },
 };
@@ -175,71 +175,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -347,6 +282,33 @@ function inferDecimals(rawValue) {
 function parseSizeToPixels(value, fallback = 0) {
   const numeric = Number.parseFloat(String(value ?? ""));
   return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+/** Parses CSS padding shorthand into edge pixel values (numbers only tokens). */
+function parsePaddingEdges(value, fallback = 16) {
+  const fb = Number.isFinite(fallback) ? fallback : 16;
+  const raw = String(value ?? "").trim();
+  if (!raw) {
+    return { top: fb, right: fb, bottom: fb, left: fb };
+  }
+  const parts = raw.split(/\s+/).map(token => parseSizeToPixels(token, NaN)).filter(n => Number.isFinite(n));
+  if (!parts.length) {
+    return { top: fb, right: fb, bottom: fb, left: fb };
+  }
+  if (parts.length === 1) {
+    const v = parts[0];
+    return { top: v, right: v, bottom: v, left: v };
+  }
+  if (parts.length === 2) {
+    const [vertical, horizontal] = parts;
+    return { top: vertical, right: horizontal, bottom: vertical, left: horizontal };
+  }
+  if (parts.length === 3) {
+    const [top, horizontal, bottom] = parts;
+    return { top, right: horizontal, bottom, left: horizontal };
+  }
+  const [top, right, bottom, left] = parts;
+  return { top, right, bottom, left };
 }
 
 function clamp(value, min, max) {
@@ -1819,14 +1781,18 @@ class NodaliaGraphCard extends HTMLElement {
     const icon = this._getIcon();
     const title = this._getTitle();
     const accentColor = chart.entries[0]?.color || legendEntries[0]?.color || "var(--primary-color)";
-    const chartHeight = `${Math.max(120, Math.min(parseSizeToPixels(styles.chart_height, 150), compactLayout ? 132 : 150))}px`;
-    const valueSize = `${Math.max(38, Math.min(parseSizeToPixels(styles.value_size, 46), compactLayout ? 42 : 46))}px`;
-    const unitSize = `${Math.max(15, Math.min(parseSizeToPixels(styles.unit_size, 18), compactLayout ? 16 : 18))}px`;
-    const titleSize = `${Math.max(13, Math.min(parseSizeToPixels(styles.title_size, 14), compactLayout ? 13 : 14))}px`;
-    const legendSize = `${Math.max(11, Math.min(parseSizeToPixels(styles.legend_size, 12), compactLayout ? 11 : 12))}px`;
+    const chartHeight = `${Math.max(136, Math.min(parseSizeToPixels(styles.chart_height, 150), compactLayout ? 148 : 172))}px`;
+    const valueSize = `${Math.max(26, Math.min(parseSizeToPixels(styles.value_size, 52), compactLayout ? 32 : 38))}px`;
+    const unitSize = `${Math.max(12, Math.min(parseSizeToPixels(styles.unit_size, 18), compactLayout ? 14 : 16))}px`;
+    const titleSize = `${Math.max(11, Math.min(parseSizeToPixels(styles.title_size, 14), compactLayout ? 11.5 : 12.5))}px`;
+    const legendSize = `${Math.max(10, Math.min(parseSizeToPixels(styles.legend_size, 12), compactLayout ? 10 : 11))}px`;
     const lineWidth = `${Math.max(1.6, Math.min(parseSizeToPixels(styles.line_width, 2.2), compactLayout ? 1.9 : 2.2))}`;
-    const cardPaddingPx = Math.max(12, parseSizeToPixels(styles.card.padding, 16));
-    const chartBleed = Math.round(cardPaddingPx * 0.95);
+    const padEdges = parsePaddingEdges(styles.card.padding, 16);
+    const cardPaddingPx = Math.max(12, Math.round((padEdges.left + padEdges.right) / 2));
+    const chartBleed = Math.round(Math.max(padEdges.left, padEdges.right, cardPaddingPx) * 0.98);
+    const chartBleedLeft = Math.round(padEdges.left);
+    const chartBleedRight = Math.round(padEdges.right);
+    const chartBleedBottom = Math.round(padEdges.bottom);
     const cardBackground = `linear-gradient(180deg, color-mix(in srgb, ${accentColor} 8%, color-mix(in srgb, var(--primary-text-color) 2%, transparent)) 0%, ${styles.card.background} 100%)`;
     const computedCardBorder = `1px solid color-mix(in srgb, ${accentColor} 20%, var(--divider-color))`;
     const cardBorder = String(styles.card.border || "").trim() && styles.card.border !== DEFAULT_CONFIG.styles.card.border
@@ -1911,7 +1877,7 @@ class NodaliaGraphCard extends HTMLElement {
         .graph-card__header {
           align-items: start;
           display: grid;
-          gap: 10px;
+          gap: 8px;
           grid-template-columns: minmax(0, 1fr) auto;
         }
 
@@ -1936,13 +1902,13 @@ class NodaliaGraphCard extends HTMLElement {
           align-items: center;
           background: linear-gradient(180deg, color-mix(in srgb, var(--primary-text-color) 6%, transparent) 0%, color-mix(in srgb, var(--primary-text-color) 3%, transparent) 100%);
           border: 1px solid color-mix(in srgb, var(--primary-text-color) 8%, transparent);
-          border-radius: 20px;
+          border-radius: 18px;
           color: ${styles.icon.color};
           display: inline-flex;
-          height: 42px;
+          height: 38px;
           justify-content: center;
           opacity: 0.9;
-          padding: 0 12px;
+          padding: 0 10px;
           position: relative;
         }
 
@@ -2009,9 +1975,9 @@ class NodaliaGraphCard extends HTMLElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 6px 8px;
+          gap: 5px 6px;
           justify-content: flex-start;
-          margin-bottom: 8px;
+          margin-bottom: 4px;
           min-height: 0;
           padding-top: 0;
         }
@@ -2029,12 +1995,12 @@ class NodaliaGraphCard extends HTMLElement {
           color: var(--primary-text-color);
           cursor: pointer;
           display: inline-flex;
-          font-size: max(11px, calc(${legendSize} - 1px));
-          gap: 8px;
-          max-width: min(100%, 192px);
+          font-size: max(10px, calc(${legendSize} - 1px));
+          gap: 6px;
+          max-width: min(100%, 184px);
           min-width: 0;
           opacity: 0.9;
-          padding: 5px 9px;
+          padding: 4px 8px;
           transform: translateZ(0);
           transform-origin: center;
           transition: opacity 160ms ease, transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
@@ -2080,19 +2046,20 @@ class NodaliaGraphCard extends HTMLElement {
             linear-gradient(180deg, color-mix(in srgb, ${accentColor} 8%, transparent) 0%, transparent 62%),
             color-mix(in srgb, var(--primary-text-color) 2%, transparent);
           border: 1px solid color-mix(in srgb, var(--primary-text-color) 7%, transparent);
-          border-radius: 20px;
+          border-radius: ${styles.card.border_radius};
           box-shadow: inset 0 1px 0 color-mix(in srgb, var(--primary-text-color) 5%, transparent);
           flex: 1 1 auto;
+          margin: 6px -${chartBleedRight}px -${chartBleedBottom}px -${chartBleedLeft}px;
+          max-width: none;
           min-height: ${chartHeight};
-          margin-inline: 0;
-          margin-top: 14px;
+          min-width: 0;
           overflow: hidden;
-          padding: 4px 0 14px;
+          padding: 4px 0 12px;
           position: relative;
           touch-action: pan-y;
           user-select: none;
           -webkit-user-select: none;
-          width: 100%;
+          width: calc(100% + ${chartBleedLeft + chartBleedRight}px);
         }
 
         .graph-card__chart-wrap--entering {
@@ -2601,14 +2568,9 @@ class NodaliaGraphCardEditorLegacy extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass) {
-    if (!hass?.states) {
-      return "";
-    }
-
-    return Object.keys(hass.states)
-      .filter(entityId => entityId.startsWith("sensor.") || entityId.startsWith("number.") || entityId.startsWith("input_number."))
-      .sort((left, right) => left.localeCompare(right, "es"))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id =>
+      id.startsWith("sensor.") || id.startsWith("number.") || id.startsWith("input_number."),
+    );
   }
 
   _captureFocusState() {
@@ -2685,7 +2647,7 @@ class NodaliaGraphCardEditorLegacy extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -3219,15 +3181,9 @@ class NodaliaGraphCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => (
-        entityId.startsWith("sensor.")
-        || entityId.startsWith("number.")
-        || entityId.startsWith("input_number.")
-      ))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id =>
+      id.startsWith("sensor.") || id.startsWith("number.") || id.startsWith("input_number."),
+    );
   }
 
   _getEntityOptions(field = "entities.0.entity", domains = []) {
@@ -3352,7 +3308,7 @@ class NodaliaGraphCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -2146,9 +2146,11 @@ class NodaliaGraphCard extends HTMLElement {
 
     tooltip.style.left = `${resolvedCenter}px`;
     tooltip.style.top = `${resolvedTop}px`;
-    tooltip.style.setProperty("--graph-tooltip-transform", shouldShowBelow
-      ? "translate(-50%, 0)"
-      : "translate(-50%, -100%)");
+    tooltip.style.setProperty(
+      "--graph-tooltip-transform",
+      shouldShowBelow ? "translate(-50%, 0)" : "translate(-50%, -100%)",
+    );
+    tooltip.style.opacity = "1";
   }
 
   _getSeriesData() {
@@ -2253,7 +2255,7 @@ class NodaliaGraphCard extends HTMLElement {
         <div
           class="graph-card__tooltip ${this._hoverEntering && animations.enabled ? "graph-card__tooltip--entering" : ""}"
           data-anchor-x-pct="${anchorXPct.toFixed(4)}"
-          style="left:${anchorXPct.toFixed(3)}%; --tooltip-tint:${escapeHtml(tooltipTint)};"
+          style="left:-9999px; top:-9999px; opacity:0; --tooltip-tint:${escapeHtml(tooltipTint)};"
         >
           <div class="graph-card__tooltip-time">${escapeHtml(hover.label)}</div>
           <div class="graph-card__tooltip-values">

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.17";
+const CARD_VERSION = "0.12.18";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -1825,7 +1825,7 @@ class NodaliaGraphCard extends HTMLElement {
     const animations = this._getAnimationSettings();
     const shouldAnimateEntrance = animations.enabled && this._animateContentOnNextRender;
     const shouldAnimateChart = animations.enabled && (shouldAnimateEntrance || this._animateChartOnNextRender);
-    const anchorXPct = graphChartXToPercent(hover.x, chart);
+    const anchorXPct = hover ? graphChartXToPercent(hover.x, chart) : 0;
     const tooltipMarkup = hover
       ? `
         <div

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.15";
+const CARD_VERSION = "0.12.16";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -25,12 +25,12 @@ const TOUCH_CLICK_SUPPRESSION_WINDOW = 350;
 const DEFAULT_CONFIG = {
   entity: "",
   entities: [],
-  name: "",
-  icon: "",
-  min: "",
-  max: "",
+  name: "Temperatura",
+  icon: "mdi:thermometer",
+  min: 15,
+  max: 25,
   hours_to_show: 24,
-  points: 480,
+  points: 100,
   show_header: true,
   show_icon: true,
   show_value: true,
@@ -54,12 +54,12 @@ const DEFAULT_CONFIG = {
       border: "1px solid var(--divider-color)",
       border_radius: "30px",
       box_shadow: "var(--ha-card-box-shadow)",
-      padding: "16px",
-      gap: "10px",
+      padding: "18px",
+      gap: "20px",
     },
     icon: {
       color: "var(--primary-text-color)",
-      size: "28px",
+      size: "20px",
     },
     title_size: "13px",
     value_size: "40px",
@@ -71,17 +71,20 @@ const DEFAULT_CONFIG = {
 };
 
 const STUB_CONFIG = {
-  name: "Humedad",
+  name: "Temperatura",
+  icon: "mdi:thermometer",
+  min: 15,
+  max: 25,
   entities: [
     {
-      entity: "sensor.termostato_dormitorios_humedad",
-      name: "Dormitorio de Rocio",
-      color: "#f29f05",
+      entity: "sensor.termostato_dormitorios_temperatura",
+      name: "Dormitorio de Rocío",
+      color: "#ffaa00",
     },
     {
-      entity: "sensor.termostato_habitaciones_comunes_humedad",
+      entity: "sensor.termostato_habitaciones_comunes_temperatura",
       name: "Pasillo",
-      color: "#42a5f5",
+      color: "#ffc677",
     },
   ],
 };
@@ -3066,7 +3069,7 @@ class NodaliaGraphCardEditorLegacy extends HTMLElement {
           </div>
           <div class="editor-grid">
             ${this._renderTextField("Nombre", "name", config.name, {
-              placeholder: "Humedad",
+              placeholder: "Temperatura",
             })}
             ${this._renderTextField("Icono", "icon", config.icon, {
               placeholder: "mdi:water-percent",

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -998,6 +998,7 @@ class NodaliaGraphCard extends HTMLElement {
     this._animateChartOnNextRender = false;
     this._lastRenderSignature = "";
     this._tooltipSyncFrame = 0;
+    this._lastTooltipViewportPosition = null;
     this._touchPressTimer = 0;
     this._touchPressState = null;
     this._touchHoverActive = false;
@@ -1412,6 +1413,7 @@ class NodaliaGraphCard extends HTMLElement {
     }
 
     this._scheduleHoverRender(null);
+    this._lastTooltipViewportPosition = null;
   }
 
   _clearTouchPressTimer() {
@@ -1554,6 +1556,9 @@ class NodaliaGraphCard extends HTMLElement {
         return;
       }
       this._hoverEntering = resolvedIndex !== null && this._hoverIndex === null;
+      if (resolvedIndex === null) {
+        this._lastTooltipViewportPosition = null;
+      }
       this._hoverIndex = resolvedIndex;
       this._render();
     });
@@ -2151,6 +2156,11 @@ class NodaliaGraphCard extends HTMLElement {
       shouldShowBelow ? "translate(-50%, 0)" : "translate(-50%, -100%)",
     );
     tooltip.style.opacity = "1";
+    this._lastTooltipViewportPosition = {
+      left: resolvedCenter,
+      top: resolvedTop,
+      transform: shouldShowBelow ? "translate(-50%, 0)" : "translate(-50%, -100%)",
+    };
   }
 
   _getSeriesData() {
@@ -2250,12 +2260,15 @@ class NodaliaGraphCard extends HTMLElement {
     const shouldAnimateEntrance = animations.enabled && this._animateContentOnNextRender;
     const shouldAnimateChart = animations.enabled && (shouldAnimateEntrance || this._animateChartOnNextRender);
     const anchorXPct = hover ? graphChartXToPercent(hover.x, chart) : 0;
+    const initialTooltipStyle = this._lastTooltipViewportPosition
+      ? `left:${this._lastTooltipViewportPosition.left}px; top:${this._lastTooltipViewportPosition.top}px; opacity:1; --graph-tooltip-transform:${this._lastTooltipViewportPosition.transform}; --tooltip-tint:${escapeHtml(tooltipTint)};`
+      : `left:-9999px; top:-9999px; opacity:0; --tooltip-tint:${escapeHtml(tooltipTint)};`;
     const tooltipMarkup = hover
       ? `
         <div
           class="graph-card__tooltip ${this._hoverEntering && animations.enabled ? "graph-card__tooltip--entering" : ""}"
           data-anchor-x-pct="${anchorXPct.toFixed(4)}"
-          style="left:-9999px; top:-9999px; opacity:0; --tooltip-tint:${escapeHtml(tooltipTint)};"
+          style="${initialTooltipStyle}"
         >
           <div class="graph-card__tooltip-time">${escapeHtml(hover.label)}</div>
           <div class="graph-card__tooltip-values">

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -355,7 +355,7 @@
 
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.19";
+const CARD_VERSION = "0.12.20";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -2474,10 +2474,13 @@ class NodaliaGraphCard extends HTMLElement {
         }
 
         .graph-card__hover-points-layer {
-          inset: 0;
+          bottom: 12px;
+          left: 0;
           overflow: hidden;
           pointer-events: none;
           position: absolute;
+          right: 0;
+          top: 4px;
           z-index: 2;
         }
 
@@ -2532,11 +2535,13 @@ class NodaliaGraphCard extends HTMLElement {
           -webkit-backdrop-filter: blur(14px);
           backdrop-filter: blur(14px);
           background:
-            linear-gradient(180deg, color-mix(in srgb, var(--tooltip-tint) 18%, rgba(255,255,255,0.09)), rgba(255,255,255,0.025)),
-            color-mix(in srgb, var(--ha-card-background, var(--card-background-color, #fff)) 86%, transparent);
-          border: 1px solid color-mix(in srgb, var(--tooltip-tint) 34%, color-mix(in srgb, var(--primary-text-color) 9%, transparent));
+            linear-gradient(180deg, color-mix(in srgb, var(--tooltip-tint) 20%, rgba(255,255,255,0.1)), rgba(255,255,255,0.02)),
+            color-mix(in srgb, var(--ha-card-background, var(--card-background-color, #fff)) 94%, rgba(255,255,255,0.02));
+          border: 1px solid color-mix(in srgb, var(--tooltip-tint) 22%, color-mix(in srgb, var(--primary-text-color) 10%, transparent));
           border-radius: 16px;
-          box-shadow: 0 16px 34px rgba(0, 0, 0, 0.28);
+          box-shadow:
+            0 10px 24px rgba(0, 0, 0, 0.24),
+            0 2px 6px color-mix(in srgb, var(--tooltip-tint) 14%, transparent);
           color: var(--primary-text-color);
           display: grid;
           gap: 8px;
@@ -2548,6 +2553,21 @@ class NodaliaGraphCard extends HTMLElement {
           transform: var(--graph-tooltip-transform, translate(-50%, -100%));
           will-change: left, top, transform;
           z-index: 2147483001;
+        }
+
+        .graph-card__tooltip::before {
+          content: "";
+          position: absolute;
+          inset: 0;
+          border-radius: inherit;
+          pointer-events: none;
+          background:
+            linear-gradient(180deg, color-mix(in srgb, var(--tooltip-tint) 18%, rgba(255,255,255,0.09)), rgba(255,255,255,0.025)),
+            color-mix(in srgb, var(--ha-card-background, var(--card-background-color, #fff)) 90%, transparent);
+          box-shadow:
+            inset 0 1px 0 color-mix(in srgb, var(--primary-text-color) 16%, transparent),
+            inset 0 -1px 0 rgba(0, 0, 0, 0.06);
+          z-index: -1;
         }
 
         .graph-card__tooltip--entering {

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -1,6 +1,361 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.18";
+const CARD_VERSION = "0.12.19";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -2460,22 +2815,33 @@ class NodaliaGraphCard extends HTMLElement {
             gap: 8px;
           }
 
-          .graph-card__legend {
-            justify-content: flex-start;
-          }
-
+          /* Keep value + legend chips on one row; scroll chips horizontally if needed
+             (wrapping pushed the chart up and overlapped the plot). */
           .graph-card__primary-row {
-            flex-wrap: wrap;
-            row-gap: 6px;
+            flex-wrap: nowrap;
+            gap: 8px 10px;
           }
 
           .graph-card__primary-row .graph-card__value {
-            flex: 1 1 auto;
+            flex: 0 1 auto;
+            min-width: 0;
           }
 
           .graph-card__primary-row .graph-card__legend {
-            flex: 1 1 100%;
-            justify-content: flex-start;
+            flex: 1 1 0;
+            flex-wrap: nowrap;
+            justify-content: flex-end;
+            margin-bottom: 0;
+            min-width: 0;
+            overflow-x: auto;
+            overscroll-behavior-x: contain;
+            scrollbar-width: thin;
+            -webkit-overflow-scrolling: touch;
+          }
+
+          .graph-card__primary-row .graph-card__legend-item {
+            flex-shrink: 0;
+            max-width: min(52vw, 160px);
           }
         }
       </style>

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.13";
+const CARD_VERSION = "0.12.14";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -1886,6 +1886,34 @@ class NodaliaGraphCard extends HTMLElement {
           animation-delay: 35ms;
         }
 
+        .graph-card__primary-row {
+          align-items: center;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          gap: 10px 14px;
+          justify-content: space-between;
+          min-height: 0;
+          min-width: 0;
+        }
+
+        .graph-card__primary-row .graph-card__value {
+          flex: 0 1 auto;
+          min-width: 0;
+        }
+
+        .graph-card__primary-row .graph-card__legend {
+          flex: 1 1 0;
+          justify-content: flex-end;
+          margin-bottom: 0;
+          min-width: 0;
+        }
+
+        .graph-card__legend--solo {
+          margin-bottom: 4px;
+          width: 100%;
+        }
+
         .graph-card__title {
           color: var(--primary-text-color);
           font-size: ${titleSize};
@@ -1950,7 +1978,8 @@ class NodaliaGraphCard extends HTMLElement {
           min-width: 0;
         }
 
-        .graph-card__content--entering .graph-card__value {
+        .graph-card__content--entering > .graph-card__value,
+        .graph-card__content--entering .graph-card__primary-row .graph-card__value {
           animation: graph-card-section-in calc(var(--graph-card-hover-duration) * 2.2) cubic-bezier(0.18, 0.9, 0.22, 1) both;
           animation-delay: 75ms;
         }
@@ -1977,12 +2006,13 @@ class NodaliaGraphCard extends HTMLElement {
           flex-wrap: wrap;
           gap: 5px 6px;
           justify-content: flex-start;
-          margin-bottom: 4px;
+          margin-bottom: 0;
           min-height: 0;
           padding-top: 0;
         }
 
-        .graph-card__content--entering .graph-card__legend {
+        .graph-card__content--entering > .graph-card__legend,
+        .graph-card__content--entering .graph-card__primary-row .graph-card__legend {
           animation: graph-card-section-in calc(var(--graph-card-hover-duration) * 2.1) cubic-bezier(0.18, 0.9, 0.22, 1) both;
           animation-delay: 105ms;
         }
@@ -2392,6 +2422,7 @@ class NodaliaGraphCard extends HTMLElement {
         .graph-card__hover-point,
         .graph-card__content,
         .graph-card__header,
+        .graph-card__primary-row,
         .graph-card__value,
         .graph-card__legend,
         .graph-card__chart-wrap,
@@ -2409,6 +2440,20 @@ class NodaliaGraphCard extends HTMLElement {
           }
 
           .graph-card__legend {
+            justify-content: flex-start;
+          }
+
+          .graph-card__primary-row {
+            flex-wrap: wrap;
+            row-gap: 6px;
+          }
+
+          .graph-card__primary-row .graph-card__value {
+            flex: 1 1 auto;
+          }
+
+          .graph-card__primary-row .graph-card__legend {
+            flex: 1 1 100%;
             justify-content: flex-start;
           }
         }
@@ -2436,7 +2481,31 @@ class NodaliaGraphCard extends HTMLElement {
           }
 
           ${
-            config.show_value !== false
+            config.show_value !== false && config.show_legend !== false
+              ? `
+                <div class="graph-card__primary-row">
+                  <div class="graph-card__value">
+                    <div class="graph-card__value-number">${escapeHtml(currentValue.value)}</div>
+                    ${currentValue.unit ? `<div class="graph-card__value-unit">${escapeHtml(currentValue.unit)}</div>` : ""}
+                  </div>
+                  <div class="graph-card__legend">
+                    ${legendEntries.map((entry, index) => `
+                      <div
+                        class="graph-card__legend-item ${entry.active ? "graph-card__legend-item--active" : ""} ${entry.muted ? "graph-card__legend-item--muted" : ""}"
+                        data-graph-series="${escapeHtml(entry.entity)}"
+                        style="--legend-color:${escapeHtml(entry.color)}; --legend-delay:${Math.min(index, 8) * 34}ms;"
+                      >
+                        <span class="graph-card__legend-dot" style="background:${escapeHtml(entry.color)};"></span>
+                        <span class="graph-card__legend-text">${escapeHtml(entry.name)}</span>
+                      </div>
+                    `).join("")}
+                  </div>
+                </div>
+              `
+              : ""
+          }
+          ${
+            config.show_value !== false && config.show_legend === false
               ? `
                 <div class="graph-card__value">
                   <div class="graph-card__value-number">${escapeHtml(currentValue.value)}</div>
@@ -2445,11 +2514,10 @@ class NodaliaGraphCard extends HTMLElement {
               `
               : ""
           }
-
           ${
-            config.show_legend !== false
+            config.show_value === false && config.show_legend !== false
               ? `
-                <div class="graph-card__legend">
+                <div class="graph-card__legend graph-card__legend--solo">
                   ${legendEntries.map((entry, index) => `
                     <div
                       class="graph-card__legend-item ${entry.active ? "graph-card__legend-item--active" : ""} ${entry.muted ? "graph-card__legend-item--muted" : ""}"

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };
@@ -967,6 +1005,7 @@ class NodaliaGraphCard extends HTMLElement {
     this._onShadowClick = this._onShadowClick.bind(this);
     this._onShadowPointerMove = this._onShadowPointerMove.bind(this);
     this._onShadowPointerLeave = this._onShadowPointerLeave.bind(this);
+    this._onHoverMediaChange = this._onHoverMediaChange.bind(this);
     this._onShadowTouchStart = this._onShadowTouchStart.bind(this);
     this._onShadowTouchMove = this._onShadowTouchMove.bind(this);
     this._onShadowTouchEnd = this._onShadowTouchEnd.bind(this);
@@ -978,6 +1017,17 @@ class NodaliaGraphCard extends HTMLElement {
     this.shadowRoot.addEventListener("touchmove", this._onShadowTouchMove, { passive: false });
     this.shadowRoot.addEventListener("touchend", this._onShadowTouchEnd);
     this.shadowRoot.addEventListener("touchcancel", this._onShadowTouchCancel);
+    // Defensive close: in some pointer transitions the shadow-root leave may be skipped.
+    this.addEventListener("pointerleave", this._onShadowPointerLeave);
+    this.addEventListener("mouseleave", this._onShadowPointerLeave);
+    this._hoverMediaQuery =
+      typeof window !== "undefined" && typeof window.matchMedia === "function"
+        ? window.matchMedia("(hover: hover)")
+        : null;
+    this._hoverSupported = this._hoverMediaQuery ? this._hoverMediaQuery.matches : true;
+    if (this._hoverMediaQuery && typeof this._hoverMediaQuery.addEventListener === "function") {
+      this._hoverMediaQuery.addEventListener("change", this._onHoverMediaChange);
+    }
   }
 
   disconnectedCallback() {
@@ -992,9 +1042,19 @@ class NodaliaGraphCard extends HTMLElement {
       this._tooltipSyncFrame = 0;
     }
     this._pendingHoverIndex = null;
+    if (this._hoverMediaQuery && typeof this._hoverMediaQuery.removeEventListener === "function") {
+      this._hoverMediaQuery.removeEventListener("change", this._onHoverMediaChange);
+    }
     this._clearTouchPressTimer();
     this._touchPressState = null;
     this._touchHoverActive = false;
+  }
+
+  _onHoverMediaChange(event) {
+    this._hoverSupported = Boolean(event?.matches);
+    if (!this._hoverSupported) {
+      this._scheduleHoverRender(null);
+    }
   }
 
   connectedCallback() {
@@ -1331,7 +1391,7 @@ class NodaliaGraphCard extends HTMLElement {
   _onShadowPointerMove(event) {
     if (
       (typeof event.pointerType === "string" && event.pointerType === "touch")
-      || (typeof window !== "undefined" && typeof window.matchMedia === "function" && !window.matchMedia("(hover: hover)").matches)
+      || this._hoverSupported === false
     ) {
       return;
     }
@@ -1477,19 +1537,26 @@ class NodaliaGraphCard extends HTMLElement {
   }
 
   _scheduleHoverRender(nextIndex) {
-    if (nextIndex === this._hoverIndex) {
+    if (nextIndex === this._hoverIndex && this._pendingHoverIndex === null) {
       return;
     }
 
+    this._pendingHoverIndex = nextIndex;
     if (this._hoverFrame) {
-      window.cancelAnimationFrame(this._hoverFrame);
-      this._hoverFrame = 0;
+      return;
     }
 
-    this._pendingHoverIndex = null;
-    this._hoverEntering = nextIndex !== null && this._hoverIndex === null;
-    this._hoverIndex = nextIndex;
-    this._render();
+    this._hoverFrame = window.requestAnimationFrame(() => {
+      this._hoverFrame = 0;
+      const resolvedIndex = this._pendingHoverIndex;
+      this._pendingHoverIndex = null;
+      if (resolvedIndex === this._hoverIndex) {
+        return;
+      }
+      this._hoverEntering = resolvedIndex !== null && this._hoverIndex === null;
+      this._hoverIndex = resolvedIndex;
+      this._render();
+    });
   }
 
   _getHistoryRequestKey() {

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.16";
+const CARD_VERSION = "0.12.17";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -316,6 +316,18 @@ function parsePaddingEdges(value, fallback = 16) {
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
+}
+
+/** Map SVG chart X (same space as viewBox width 100, incl. negative pad) to overlay %. */
+function graphChartXToPercent(x, chart) {
+  if (!chart || typeof chart.xMin !== "number" || typeof chart.xMax !== "number") {
+    return 50;
+  }
+  const span = chart.xMax - chart.xMin;
+  if (!Number.isFinite(span) || span <= 0) {
+    return 50;
+  }
+  return ((x - chart.xMin) / span) * 100;
 }
 
 function escapeSelectorValue(value) {
@@ -1546,12 +1558,20 @@ class NodaliaGraphCard extends HTMLElement {
     // Reserve extra bottom headroom so min values and stroke/glow
     // never get clipped by the rounded chart container.
     const paddingBottom = 14;
+    const spanX = width - (paddingX * 2);
+    const xMin = paddingX;
+    const xMax = paddingX + spanX;
     const bounds = this._getGraphBounds(series);
     const range = Math.max(bounds.max - bounds.min, 1);
 
     return {
       width,
       height,
+      paddingX,
+      paddingTop,
+      paddingBottom,
+      xMin,
+      xMax,
       entries: series.map(entry => {
         if (!entry.samples.length) {
           return {
@@ -1563,7 +1583,7 @@ class NodaliaGraphCard extends HTMLElement {
         }
 
         const points = entry.samples.map((sample, index) => {
-          const x = paddingX + ((width - (paddingX * 2)) * index) / Math.max(entry.samples.length - 1, 1);
+          const x = paddingX + (spanX * index) / Math.max(entry.samples.length - 1, 1);
           const normalized = clamp((sample.value - bounds.min) / range, 0, 1);
           const y = paddingTop + ((height - paddingTop - paddingBottom) * (1 - normalized));
           return { x, y };
@@ -1645,9 +1665,8 @@ class NodaliaGraphCard extends HTMLElement {
       return;
     }
 
-    const chartWidth = Number(tooltip.dataset.chartWidth || 0);
-    const anchorX = Number(tooltip.dataset.anchorX || 0);
-    if (!Number.isFinite(chartWidth) || chartWidth <= 0) {
+    const anchorXPct = Number(tooltip.dataset.anchorXPct);
+    if (!Number.isFinite(anchorXPct)) {
       return;
     }
 
@@ -1676,7 +1695,7 @@ class NodaliaGraphCard extends HTMLElement {
       || (typeof window !== "undefined" ? window.innerHeight : 0)
       || 640;
     const chartRect = chartWrap.getBoundingClientRect();
-    const anchorPx = clamp((anchorX / chartWidth) * chartRect.width, 0, chartRect.width);
+    const anchorPx = clamp((anchorXPct / 100) * chartRect.width, 0, chartRect.width);
     const anchorViewportX = chartRect.left + anchorPx;
     const anchorViewportY = chartRect.top + Math.max(22, chartRect.height * 0.28);
     const maxTooltipWidth = Math.min(260, viewportWidth - 24);
@@ -1806,13 +1825,13 @@ class NodaliaGraphCard extends HTMLElement {
     const animations = this._getAnimationSettings();
     const shouldAnimateEntrance = animations.enabled && this._animateContentOnNextRender;
     const shouldAnimateChart = animations.enabled && (shouldAnimateEntrance || this._animateChartOnNextRender);
+    const anchorXPct = graphChartXToPercent(hover.x, chart);
     const tooltipMarkup = hover
       ? `
         <div
           class="graph-card__tooltip ${this._hoverEntering && animations.enabled ? "graph-card__tooltip--entering" : ""}"
-          data-anchor-x="${hover.x.toFixed(2)}"
-          data-chart-width="${chart.width}"
-          style="left:${((hover.x / chart.width) * 100).toFixed(2)}%; --tooltip-tint:${escapeHtml(tooltipTint)};"
+          data-anchor-x-pct="${anchorXPct.toFixed(4)}"
+          style="left:${anchorXPct.toFixed(3)}%; --tooltip-tint:${escapeHtml(tooltipTint)};"
         >
           <div class="graph-card__tooltip-time">${escapeHtml(hover.label)}</div>
           <div class="graph-card__tooltip-values">
@@ -2124,47 +2143,34 @@ class NodaliaGraphCard extends HTMLElement {
         .graph-card__hover-point {
           align-items: center;
           display: inline-flex;
-          height: 12px;
+          height: 14px;
           justify-content: center;
           left: 0;
           pointer-events: none;
           position: absolute;
           top: 0;
           transform: translate(-50%, -50%);
-          width: 12px;
+          width: 14px;
           z-index: 3;
         }
 
-        .graph-card__hover-point-halo {
-          background: radial-gradient(circle, color-mix(in srgb, var(--hover-color) 24%, transparent) 0 42%, transparent 72%);
-          border-radius: 999px;
-          inset: -8px;
-          opacity: 0.9;
-          position: absolute;
-        }
-
-        .graph-card__hover-point-outer {
-          background:
-            linear-gradient(180deg, color-mix(in srgb, var(--hover-color) 32%, rgba(255,255,255,0.76)), color-mix(in srgb, var(--ha-card-background, #1f1f24) 72%, var(--hover-color)));
-          border: 1px solid color-mix(in srgb, var(--hover-color) 52%, rgba(255, 255, 255, 0.34));
+        .graph-card__hover-dot {
+          background: radial-gradient(
+            circle at 35% 35%,
+            rgba(255, 255, 255, 0.98) 0 35%,
+            color-mix(in srgb, var(--dot-color) 44%, rgba(255, 255, 255, 0.92)) 36% 100%
+          );
           border-radius: 999px;
           box-shadow:
-            0 8px 18px rgba(0, 0, 0, 0.18),
-            inset 0 1px 0 rgba(255, 255, 255, 0.3);
-          inset: 0;
-          position: absolute;
-        }
-
-        .graph-card__hover-point-ring {
-          background: color-mix(in srgb, var(--hover-color) 82%, rgba(255, 255, 255, 0.86));
-          border-radius: 999px;
-          box-shadow: 0 0 10px color-mix(in srgb, var(--hover-color) 34%, transparent);
-          height: 4.5px;
-          left: 50%;
-          position: absolute;
-          top: 50%;
-          transform: translate(-50%, -50%);
-          width: 4.5px;
+            0 0 0 3px color-mix(in srgb, var(--dot-color) 14%, transparent),
+            0 0 10px color-mix(in srgb, var(--dot-color) 20%, transparent);
+          display: block;
+          flex-shrink: 0;
+          height: 8px;
+          width: 8px;
+          animation: graph-card-hover-dot-pulse calc(var(--graph-card-hover-duration, 180ms) * 2.35) ease-in-out infinite alternate;
+          transform-origin: center;
+          will-change: transform;
         }
 
         .graph-card__tooltip {
@@ -2407,6 +2413,17 @@ class NodaliaGraphCard extends HTMLElement {
           }
         }
 
+        @keyframes graph-card-hover-dot-pulse {
+          0% {
+            opacity: 1;
+            transform: scale(1);
+          }
+          100% {
+            opacity: 0.94;
+            transform: scale(1.14);
+          }
+        }
+
         @keyframes graph-card-hover-line-in {
           0% { opacity: 0; }
           100% { opacity: 1; }
@@ -2423,6 +2440,7 @@ class NodaliaGraphCard extends HTMLElement {
         .graph-card__tooltip,
         .graph-card__hover-line,
         .graph-card__hover-point,
+        .graph-card__hover-dot,
         .graph-card__content,
         .graph-card__header,
         .graph-card__primary-row,
@@ -2574,13 +2592,11 @@ class NodaliaGraphCard extends HTMLElement {
                       if (!point) {
                         return "";
                       }
-                      const left = clamp((point.x / chart.width) * 100, 1.8, 98.2);
-                      const top = clamp((point.y / chart.height) * 100, 4, 96);
+                      const left = clamp(graphChartXToPercent(point.x, chart), 0.3, 99.7);
+                      const top = clamp((point.y / chart.height) * 100, 0.3, 99.7);
                       return `
-                        <span class="graph-card__hover-point" style="left:${left}%; top:${top}%; --hover-color:${escapeHtml(entry.color)};">
-                          <span class="graph-card__hover-point-halo"></span>
-                          <span class="graph-card__hover-point-outer"></span>
-                          <span class="graph-card__hover-point-ring"></span>
+                        <span class="graph-card__hover-point" style="left:${left}%; top:${top}%; --dot-color:${escapeHtml(entry.color)};">
+                          <span class="graph-card__hover-dot"></span>
                         </span>
                       `;
                     }).join("")}

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-graph-card";
 const EDITOR_TAG = "nodalia-graph-card-editor";
-const CARD_VERSION = "0.12.14";
+const CARD_VERSION = "0.12.15";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -2079,7 +2079,7 @@ class NodaliaGraphCard extends HTMLElement {
           border-radius: ${styles.card.border_radius};
           box-shadow: inset 0 1px 0 color-mix(in srgb, var(--primary-text-color) 5%, transparent);
           flex: 1 1 auto;
-          margin: 6px -${chartBleedRight}px -${chartBleedBottom}px -${chartBleedLeft}px;
+          margin: 14px -${chartBleedRight}px -${chartBleedBottom}px -${chartBleedLeft}px;
           max-width: none;
           min-height: ${chartHeight};
           min-width: 0;

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -673,16 +673,16 @@ function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
 
-/** Map SVG chart X (same space as viewBox width 100, incl. negative pad) to overlay %. */
+/** Map SVG viewBox X (0..chart.width) to overlay percentage. */
 function graphChartXToPercent(x, chart) {
-  if (!chart || typeof chart.xMin !== "number" || typeof chart.xMax !== "number") {
+  if (!chart || typeof chart.width !== "number") {
     return 50;
   }
-  const span = chart.xMax - chart.xMin;
-  if (!Number.isFinite(span) || span <= 0) {
+  const width = chart.width;
+  if (!Number.isFinite(width) || width <= 0) {
     return 50;
   }
-  return ((x - chart.xMin) / span) * 100;
+  return (x / width) * 100;
 }
 
 function escapeSelectorValue(value) {
@@ -2252,10 +2252,11 @@ class NodaliaGraphCard extends HTMLElement {
         }
 
         .graph-card__header {
-          align-items: start;
-          display: grid;
+          align-items: center;
+          display: flex;
           gap: 8px;
-          grid-template-columns: minmax(0, 1fr) auto;
+          justify-content: flex-start;
+          min-width: 0;
         }
 
         .graph-card__content--entering .graph-card__header {
@@ -2871,7 +2872,6 @@ class NodaliaGraphCard extends HTMLElement {
             config.show_header !== false
               ? `
                 <div class="graph-card__header">
-                  <div class="graph-card__title">${escapeHtml(title)}</div>
                   ${
                     config.show_icon !== false
                       ? `
@@ -2882,6 +2882,7 @@ class NodaliaGraphCard extends HTMLElement {
                       `
                       : ""
                   }
+                  <div class="graph-card__title">${escapeHtml(title)}</div>
                 </div>
               `
               : ""

--- a/nodalia-graph-card.js
+++ b/nodalia-graph-card.js
@@ -2275,6 +2275,10 @@ class NodaliaGraphCard extends HTMLElement {
           min-width: 0;
         }
 
+        .graph-card__header + .graph-card__primary-row {
+          margin-top: 6px;
+        }
+
         .graph-card__primary-row .graph-card__value {
           flex: 0 1 auto;
           min-width: 0;

--- a/nodalia-humidifier-card.js
+++ b/nodalia-humidifier-card.js
@@ -174,71 +174,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -2892,11 +2827,12 @@ class NodaliaHumidifierCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("humidifier.") || entityId.startsWith("select.") || entityId.startsWith("input_select."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(
+      hass,
+      this._config?.language,
+      id =>
+        id.startsWith("humidifier.") || id.startsWith("select.") || id.startsWith("input_select."),
+    );
   }
 
   _getHumidifierEntityOptions() {
@@ -3039,7 +2975,7 @@ class NodaliaHumidifierCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-humidifier-card.js
+++ b/nodalia-humidifier-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-humidifier-card.js
+++ b/nodalia-humidifier-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-humidifier-card";
 const EDITOR_TAG = "nodalia-humidifier-card-editor";
 const CARD_VERSION = "0.6.3";

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.8";
+const CARD_VERSION = "0.2.9";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -884,8 +884,8 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         :host([data-icon-only]) {
-          /* Same cross-axis behavior as non–icon-only pills (`align-items: center` on row).
-             `stretch` forced full line height and skewed vertical center vs text pills + menu. */
+          /* Same cross-axis behavior as non–icon-only pills (align-items: center on row).
+             stretch forced full line height and skewed vertical center vs text pills + menu. */
           align-self: var(--insignia-icon-only-align-self, center);
           box-sizing: border-box;
           display: flex;

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.3";
+const CARD_VERSION = "0.2.4";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -810,6 +810,7 @@ class NodaliaInsigniaCard extends HTMLElement {
     const state = this._getState();
 
     if (!state && !config.name && !config.icon) {
+      this.removeAttribute("data-icon-only");
       this.shadowRoot.innerHTML = `
         <style>
           :host { display: block; }
@@ -886,6 +887,7 @@ class NodaliaInsigniaCard extends HTMLElement {
           justify-content: center;
           overflow: visible;
           width: auto;
+          margin-block: var(--insignia-scroll-strip-margin-block, 8px);
         }
 
         * {

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -355,7 +355,7 @@
 
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.10";
+const CARD_VERSION = "0.2.11";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -544,6 +544,29 @@ function deleteByPath(target, path) {
 function parseSizeToPixels(value, fallback = 0) {
   const numeric = Number.parseFloat(String(value ?? ""));
   return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+/** Sum of top + bottom padding from CSS shorthand (px numbers). */
+function parsePaddingVertical(padding, fallback = 8) {
+  const raw = String(padding ?? "").trim();
+  if (!raw) {
+    return fallback;
+  }
+  const tokens = raw.split(/\s+/).filter(Boolean);
+  const px = tokens.map(token => parseSizeToPixels(token, Number.NaN)).filter(n => Number.isFinite(n));
+  if (!px.length) {
+    return fallback;
+  }
+  if (px.length === 1) {
+    return px[0] * 2;
+  }
+  if (px.length === 2) {
+    return px[0] * 2;
+  }
+  if (px.length === 3) {
+    return px[0] + px[2];
+  }
+  return px[0] + px[2];
 }
 
 function normalizeTextKey(value) {
@@ -1220,9 +1243,16 @@ class NodaliaInsigniaCard extends HTMLElement {
     const showName = config.show_name !== false;
     const showValue = config.show_value !== false && Boolean(value);
     const iconOnly = !showName && !showValue;
-    const iconOnlySize = Math.max(36, Math.min(iconSizePx + 12, 46));
-    const iconOnlyIconBase = parseSizeToPixels(styles.icon?.size, iconSizePx);
-    const iconOnlyIconSize = Math.max(18, Math.min(Math.round(iconOnlyIconBase), iconOnlySize - 12));
+    const cardPaddingVertical = parsePaddingVertical(
+      styles.card?.padding ?? DEFAULT_CONFIG.styles.card.padding,
+      8,
+    );
+    // Outer square matches pill height: vertical padding + icon disc (same as non–icon-only row).
+    const iconOnlySize = cardPaddingVertical + iconSizePx;
+    const iconOnlyContentInset = 6;
+    const iconOnlyInner = Math.max(0, iconOnlySize - iconOnlyContentInset);
+    const iconGlyphDefault = Math.round(iconSizePx * 0.5);
+    const iconOnlyIconSize = Math.max(16, Math.min(iconGlyphDefault, iconOnlyInner));
     const iconOnlyOffsetY = String(styles.icon?.icon_only_offset_y ?? DEFAULT_CONFIG.styles.icon.icon_only_offset_y);
     const pictureUrl = this._getResolvedPicture(state);
     const showPicture = Boolean(pictureUrl);
@@ -1250,9 +1280,10 @@ class NodaliaInsigniaCard extends HTMLElement {
           width: auto;
           min-height: min-content;
           transform: translateY(var(--insignia-icon-only-row-nudge, -2px));
+          /* Default 0 so icon-only height matches the text pill; use vars in horizontal scroll strips. */
           padding-block: var(
             --insignia-scroll-strip-padding-block,
-            var(--insignia-scroll-strip-margin-block, 4px)
+            var(--insignia-scroll-strip-margin-block, 0px)
           );
         }
 

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.4";
+const CARD_VERSION = "0.2.5";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -884,10 +884,18 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         :host([data-icon-only]) {
+          align-self: stretch;
+          box-sizing: border-box;
+          display: flex;
+          align-items: center;
           justify-content: center;
           overflow: visible;
           width: auto;
-          margin-block: var(--insignia-scroll-strip-margin-block, 8px);
+          min-height: min-content;
+          padding-block: var(
+            --insignia-scroll-strip-padding-block,
+            var(--insignia-scroll-strip-margin-block, 4px)
+          );
         }
 
         * {
@@ -1033,7 +1041,11 @@ class NodaliaInsigniaCard extends HTMLElement {
           overflow: visible;
           position: relative;
           top: var(--icon-only-offset-y);
-          transform: translateY(0) !important;
+          transform: translateY(var(--insignia-icon-optical-y, -1px)) !important;
+        }
+
+        .insignia-card--icon-only .insignia-card__icon ha-icon svg {
+          display: block;
         }
 
         .insignia-card__copy {

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -693,6 +693,48 @@ function escapeSelectorValue(value) {
   return String(value ?? "").replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
+function sanitizeCssValue(value, fallback) {
+  const raw = String(value ?? "").trim();
+  const safeFallback = String(fallback ?? "").trim();
+  if (!raw) {
+    return safeFallback;
+  }
+  if (/[\u0000-\u001f\u007f<>;"'{}]/.test(raw) || raw.includes("/*") || raw.includes("*/")) {
+    return safeFallback;
+  }
+  return raw;
+}
+
+function getSafeStyles(styles = DEFAULT_CONFIG.styles) {
+  const defaults = DEFAULT_CONFIG.styles;
+  const card = styles?.card || {};
+  const icon = styles?.icon || {};
+  const tint = styles?.tint || {};
+
+  return {
+    card: {
+      background: sanitizeCssValue(card.background, defaults.card.background),
+      border: sanitizeCssValue(card.border, defaults.card.border),
+      border_radius: sanitizeCssValue(card.border_radius, defaults.card.border_radius),
+      box_shadow: sanitizeCssValue(card.box_shadow, defaults.card.box_shadow),
+      gap: sanitizeCssValue(card.gap, defaults.card.gap),
+      padding: sanitizeCssValue(card.padding, defaults.card.padding),
+    },
+    icon: {
+      background: sanitizeCssValue(icon.background, defaults.icon.background),
+      icon_only_offset_y: sanitizeCssValue(icon.icon_only_offset_y, defaults.icon.icon_only_offset_y),
+      off_color: sanitizeCssValue(icon.off_color, defaults.icon.off_color),
+      on_color: sanitizeCssValue(icon.on_color, defaults.icon.on_color),
+      size: sanitizeCssValue(icon.size, defaults.icon.size),
+    },
+    tint: {
+      color: sanitizeCssValue(tint.color, defaults.tint.color),
+    },
+    title_size: sanitizeCssValue(styles?.title_size, defaults.title_size),
+    value_size: sanitizeCssValue(styles?.value_size, defaults.value_size),
+  };
+}
+
 function clampNumber(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
@@ -1030,7 +1072,7 @@ class NodaliaInsigniaCard extends HTMLElement {
 
   _getTintColor(state) {
     if (this._config?.tint_auto === false) {
-      return this._config?.styles?.tint?.color || DEFAULT_CONFIG.styles.tint.color;
+      return sanitizeCssValue(this._config?.styles?.tint?.color, DEFAULT_CONFIG.styles.tint.color);
     }
 
     const domain = getEntityDomain(state);
@@ -1161,7 +1203,7 @@ class NodaliaInsigniaCard extends HTMLElement {
     }
 
     const config = this._config || normalizeConfig({});
-    const styles = config.styles || DEFAULT_CONFIG.styles;
+    const styles = getSafeStyles(config.styles);
     const state = this._getState();
 
     if (!state && !config.name && !config.icon) {
@@ -1203,7 +1245,7 @@ class NodaliaInsigniaCard extends HTMLElement {
     const icon = this._getResolvedIcon(state);
     const active = this._isActive(state);
     const dimIcon = this._shouldDimIcon(state);
-    const tint = this._getTintColor(state);
+    const tint = sanitizeCssValue(this._getTintColor(state), DEFAULT_CONFIG.styles.tint.color);
     const strongTint = this._shouldApplyStrongCardTint(state);
     const cardBackground = strongTint
       ? `linear-gradient(135deg, color-mix(in srgb, ${tint} 18%, ${styles.card.background}) 0%, color-mix(in srgb, ${tint} 10%, ${styles.card.background}) 52%, ${styles.card.background} 100%)`

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -355,7 +355,7 @@
 
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.11";
+const CARD_VERSION = "0.2.12";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -544,29 +544,6 @@ function deleteByPath(target, path) {
 function parseSizeToPixels(value, fallback = 0) {
   const numeric = Number.parseFloat(String(value ?? ""));
   return Number.isFinite(numeric) ? numeric : fallback;
-}
-
-/** Sum of top + bottom padding from CSS shorthand (px numbers). */
-function parsePaddingVertical(padding, fallback = 8) {
-  const raw = String(padding ?? "").trim();
-  if (!raw) {
-    return fallback;
-  }
-  const tokens = raw.split(/\s+/).filter(Boolean);
-  const px = tokens.map(token => parseSizeToPixels(token, Number.NaN)).filter(n => Number.isFinite(n));
-  if (!px.length) {
-    return fallback;
-  }
-  if (px.length === 1) {
-    return px[0] * 2;
-  }
-  if (px.length === 2) {
-    return px[0] * 2;
-  }
-  if (px.length === 3) {
-    return px[0] + px[2];
-  }
-  return px[0] + px[2];
 }
 
 function normalizeTextKey(value) {
@@ -1243,16 +1220,6 @@ class NodaliaInsigniaCard extends HTMLElement {
     const showName = config.show_name !== false;
     const showValue = config.show_value !== false && Boolean(value);
     const iconOnly = !showName && !showValue;
-    const cardPaddingVertical = parsePaddingVertical(
-      styles.card?.padding ?? DEFAULT_CONFIG.styles.card.padding,
-      8,
-    );
-    // Outer square matches pill height: vertical padding + icon disc (same as non–icon-only row).
-    const iconOnlySize = cardPaddingVertical + iconSizePx;
-    const iconOnlyContentInset = 6;
-    const iconOnlyInner = Math.max(0, iconOnlySize - iconOnlyContentInset);
-    const iconGlyphDefault = Math.round(iconSizePx * 0.5);
-    const iconOnlyIconSize = Math.max(16, Math.min(iconGlyphDefault, iconOnlyInner));
     const iconOnlyOffsetY = String(styles.icon?.icon_only_offset_y ?? DEFAULT_CONFIG.styles.icon.icon_only_offset_y);
     const pictureUrl = this._getResolvedPicture(state);
     const showPicture = Boolean(pictureUrl);
@@ -1280,10 +1247,9 @@ class NodaliaInsigniaCard extends HTMLElement {
           width: auto;
           min-height: min-content;
           transform: translateY(var(--insignia-icon-only-row-nudge, -2px));
-          /* Default 0 so icon-only height matches the text pill; use vars in horizontal scroll strips. */
           padding-block: var(
             --insignia-scroll-strip-padding-block,
-            var(--insignia-scroll-strip-margin-block, 0px)
+            var(--insignia-scroll-strip-margin-block, 4px)
           );
         }
 
@@ -1312,13 +1278,9 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         .insignia-card--icon-only {
           border-radius: ${styles.card.border_radius};
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          height: var(--icon-only-size);
-          min-height: var(--icon-only-size);
-          min-width: var(--icon-only-size);
-          width: var(--icon-only-size);
+          height: auto;
+          width: fit-content;
+          max-width: 100%;
         }
 
         .insignia-card::before {
@@ -1358,17 +1320,11 @@ class NodaliaInsigniaCard extends HTMLElement {
           z-index: 1;
         }
 
+        /* Solo icono: misma fila / padding / gap que la píldora con texto; sin segunda columna (no forzar cuadrado). */
         .insignia-card--icon-only .insignia-card__content {
-          align-items: center;
-          border-radius: inherit;
-          box-sizing: border-box;
-          display: grid;
-          place-items: center;
-          margin: 0;
-          padding: 3px;
-          grid-template-columns: 1fr;
-          width: 100%;
-          height: 100%;
+          grid-template-columns: min(${iconSizePx}px, 100%);
+          width: fit-content;
+          max-width: 100%;
         }
 
         .insignia-card__icon {
@@ -1389,25 +1345,6 @@ class NodaliaInsigniaCard extends HTMLElement {
           width: ${iconSizePx}px;
         }
 
-        .insignia-card--icon-only .insignia-card__icon {
-          align-self: center;
-          border-radius: inherit;
-          justify-self: center;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          line-height: 0;
-          height: 100%;
-          margin: 0;
-          width: 100%;
-        }
-
-        .insignia-card--icon-only .insignia-card__icon {
-          background: transparent;
-          border: none;
-          box-shadow: none;
-        }
-
         .insignia-card__icon img {
           border-radius: inherit;
           height: 100%;
@@ -1422,21 +1359,10 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         .insignia-card--icon-only .insignia-card__icon ha-icon {
-          --mdc-icon-size: var(--icon-only-icon-size);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          height: var(--icon-only-icon-size);
-          width: var(--icon-only-icon-size);
-          line-height: 0;
           overflow: visible;
           position: relative;
           top: var(--icon-only-offset-y);
-          transform: translateY(var(--insignia-icon-optical-y, -1px)) !important;
-        }
-
-        .insignia-card--icon-only .insignia-card__icon ha-icon svg {
-          display: block;
+          transform: translateY(var(--insignia-icon-optical-y, -1px));
         }
 
         .insignia-card__copy {
@@ -1499,7 +1425,7 @@ class NodaliaInsigniaCard extends HTMLElement {
           width: 10px;
         }
       </style>
-      <div class="insignia-card ${iconOnly ? "insignia-card--icon-only" : ""}" style="--icon-only-size: ${iconOnlySize}px; --icon-only-icon-size: ${iconOnlyIconSize}px; --icon-only-offset-y: ${iconOnlyOffsetY}; ${isVisible ? "" : "display:none;"}">
+      <div class="insignia-card ${iconOnly ? "insignia-card--icon-only" : ""}" style="--icon-only-offset-y: ${iconOnlyOffsetY}; ${isVisible ? "" : "display:none;"}">
         <div class="insignia-card__content" data-insignia-action="primary">
           <div class="insignia-card__icon">
             ${showPicture
@@ -1508,11 +1434,15 @@ class NodaliaInsigniaCard extends HTMLElement {
             }
             ${unavailable ? '<span class="insignia-card__unavailable-badge"><ha-icon icon="mdi:help"></ha-icon></span>' : ""}
           </div>
+          ${iconOnly
+            ? ""
+            : `
           <div class="insignia-card__copy">
             ${showName ? `<div class="insignia-card__title">${escapeHtml(title)}</div>` : ""}
             ${showName && showValue ? '<span class="insignia-card__dot"></span>' : ""}
             ${showValue ? `<div class="insignia-card__value">${escapeHtml(value)}</div>` : ""}
           </div>
+          `}
         </div>
       </div>
     `;

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.5";
+const CARD_VERSION = "0.2.6";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -892,6 +892,7 @@ class NodaliaInsigniaCard extends HTMLElement {
           overflow: visible;
           width: auto;
           min-height: min-content;
+          transform: translateY(var(--insignia-icon-only-row-nudge, -2px));
           padding-block: var(
             --insignia-scroll-strip-padding-block,
             var(--insignia-scroll-strip-margin-block, 4px)

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -1,6 +1,361 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.9";
+const CARD_VERSION = "0.2.10";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -925,7 +1280,7 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         .insignia-card--icon-only {
-          border-radius: 999px;
+          border-radius: ${styles.card.border_radius};
           display: flex;
           align-items: center;
           justify-content: center;
@@ -974,6 +1329,7 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         .insignia-card--icon-only .insignia-card__content {
           align-items: center;
+          border-radius: inherit;
           box-sizing: border-box;
           display: grid;
           place-items: center;
@@ -1004,6 +1360,7 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         .insignia-card--icon-only .insignia-card__icon {
           align-self: center;
+          border-radius: inherit;
           justify-self: center;
           display: flex;
           align-items: center;
@@ -1021,7 +1378,7 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         .insignia-card__icon img {
-          border-radius: 999px;
+          border-radius: inherit;
           height: 100%;
           object-fit: cover;
           width: 100%;

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.2";
+const CARD_VERSION = "0.2.3";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -866,7 +866,7 @@ class NodaliaInsigniaCard extends HTMLElement {
     const iconOnly = !showName && !showValue;
     const iconOnlySize = Math.max(36, Math.min(iconSizePx + 12, 46));
     const iconOnlyIconBase = parseSizeToPixels(styles.icon?.size, iconSizePx);
-    const iconOnlyIconSize = Math.max(18, Math.min(Math.round(iconOnlyIconBase), iconOnlySize - 8));
+    const iconOnlyIconSize = Math.max(18, Math.min(Math.round(iconOnlyIconBase), iconOnlySize - 12));
     const iconOnlyOffsetY = String(styles.icon?.icon_only_offset_y ?? DEFAULT_CONFIG.styles.icon.icon_only_offset_y);
     const pictureUrl = this._getResolvedPicture(state);
     const showPicture = Boolean(pictureUrl);
@@ -961,10 +961,11 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         .insignia-card--icon-only .insignia-card__content {
           align-items: center;
+          box-sizing: border-box;
           display: grid;
           place-items: center;
           margin: 0;
-          padding: 0;
+          padding: 3px;
           grid-template-columns: 1fr;
           width: 100%;
           height: 100%;
@@ -1021,12 +1022,13 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         .insignia-card--icon-only .insignia-card__icon ha-icon {
           --mdc-icon-size: var(--icon-only-icon-size);
-          height: var(--icon-only-icon-size);
-          width: var(--icon-only-icon-size);
-          line-height: var(--icon-only-icon-size);
           display: flex;
           align-items: center;
           justify-content: center;
+          height: var(--icon-only-icon-size);
+          width: var(--icon-only-icon-size);
+          line-height: 0;
+          overflow: visible;
           position: relative;
           top: var(--icon-only-offset-y);
           transform: translateY(0) !important;

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.0";
+const CARD_VERSION = "0.2.1";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -15,6 +15,8 @@ const DEFAULT_CONFIG = {
   entity: "",
   name: "",
   icon: "",
+  icon_active: "",
+  icon_inactive: "",
   use_entity_icon: false,
   use_entity_picture: false,
   state_attribute: "",
@@ -157,71 +159,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -607,12 +544,33 @@ class NodaliaInsigniaCard extends HTMLElement {
     return unit ? `${formatted} ${unit}` : formatted;
   }
 
-  _getResolvedIcon(state) {
-    if (this._config.use_entity_icon) {
-      return getDynamicEntityIcon(state) || this._config.icon || "mdi:star-four-points-circle";
+  _isActiveState(state) {
+    const stateKey = normalizeTextKey(state?.state);
+
+    if (!stateKey || ["off", "closed", "locked", "unavailable", "unknown", "none", "idle", "standby"].includes(stateKey)) {
+      return false;
     }
 
-    return this._config.icon || state?.attributes?.icon || "mdi:star-four-points-circle";
+    return true;
+  }
+
+  _getResolvedIcon(state) {
+    const trimIcon = value => (typeof value === "string" ? value.trim() : "");
+    const iconActive = trimIcon(this._config?.icon_active);
+    const iconInactive = trimIcon(this._config?.icon_inactive);
+
+    if (iconActive || iconInactive) {
+      const chosen = this._isActiveState(state) ? iconActive : iconInactive;
+      if (chosen) {
+        return chosen;
+      }
+    }
+
+    if (this._config.use_entity_icon) {
+      return getDynamicEntityIcon(state) || trimIcon(this._config?.icon) || "mdi:star-four-points-circle";
+    }
+
+    return trimIcon(this._config?.icon) || state?.attributes?.icon || "mdi:star-four-points-circle";
   }
 
   _getResolvedPicture(state) {
@@ -1194,13 +1152,7 @@ class NodaliaInsigniaCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    const tag = window.NodaliaI18n.localeTag(
-      window.NodaliaI18n.resolveLanguage(hass, this._config?.language ?? "auto"),
-    );
-    return `${tag}|${Object.entries(hass?.states || {})
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}`)
-      .sort((left, right) => left.localeCompare(right, tag, { sensitivity: "base" }))
-      .join("|")}`;
+    return window.NodaliaUtils.editorStatesSignature(hass, this._config?.language ?? "auto");
   }
 
   _watchEditorControlTag(tagName) {
@@ -1315,7 +1267,7 @@ class NodaliaInsigniaCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -1550,91 +1502,25 @@ class NodaliaInsigniaCardEditor extends HTMLElement {
   }
 
   _mountEntityPicker(host) {
-    if (!(host instanceof HTMLElement)) {
-      return;
-    }
-
-    const field = host.dataset.field || "entity";
-    const nextValue = host.dataset.value || "";
-    let control = null;
-
-    if (customElements.get("ha-entity-picker")) {
-      control = document.createElement("ha-entity-picker");
-      control.allowCustomEntity = true;
-    } else if (customElements.get("ha-selector")) {
-      control = document.createElement("ha-selector");
-      control.selector = {
-        entity: {},
-      };
-    } else {
-      control = document.createElement("input");
-      control.type = "text";
-      control.dataset.field = field;
-      control.value = nextValue;
-      control.addEventListener("change", this._onShadowInput);
-    }
-
-    control.dataset.field = field;
-    control.dataset.value = nextValue;
-
-    if ("hass" in control) {
-      control.hass = this._hass;
-    }
-
-    if ("value" in control) {
-      control.value = nextValue;
-    }
-
-    if (control.tagName !== "INPUT") {
-      control.addEventListener("value-changed", this._onShadowValueChanged);
-    }
-
-    host.replaceChildren(control);
-  }
-
-  _copyDatasetToControl(host, control) {
-    Object.entries(host.dataset || {}).forEach(([key, value]) => {
-      if (key === "mountedControl" || key === "value" || key === "placeholder") {
-        return;
-      }
-      control.dataset[key] = value;
+    window.NodaliaUtils.mountEntityPickerHost(host, {
+      hass: this._hass,
+      field: host.dataset.field || "entity",
+      value: host.dataset.value || "",
+      onShadowInput: this._onShadowInput,
+      onShadowValueChanged: this._onShadowValueChanged,
+      copyDatasetFromHost: true,
     });
   }
 
   _mountIconPicker(host) {
-    if (!(host instanceof HTMLElement)) {
-      return;
-    }
-
-    const nextValue = host.dataset.value || "";
-    const placeholder = host.dataset.placeholder || "";
-    let control = null;
-
-    if (customElements.get("ha-icon-picker")) {
-      control = document.createElement("ha-icon-picker");
-    } else {
-      control = document.createElement("input");
-      control.type = "text";
-    }
-
-    this._copyDatasetToControl(host, control);
-
-    if ("hass" in control) {
-      control.hass = this._hass;
-    }
-    if (placeholder && "placeholder" in control) {
-      control.placeholder = placeholder;
-    }
-    if ("value" in control) {
-      control.value = nextValue;
-    }
-    if (control.tagName !== "INPUT") {
-      control.addEventListener("value-changed", this._onShadowValueChanged);
-    } else {
-      control.addEventListener("change", this._onShadowInput);
-    }
-
-    host.replaceChildren(control);
+    window.NodaliaUtils.mountIconPickerHost(host, {
+      hass: this._hass,
+      value: host.dataset.value || "",
+      placeholder: host.dataset.placeholder || "",
+      onShadowInput: this._onShadowInput,
+      onShadowValueChanged: this._onShadowValueChanged,
+      copyDatasetFromHost: true,
+    });
   }
 
   _render() {
@@ -1905,6 +1791,21 @@ class NodaliaInsigniaCardEditor extends HTMLElement {
               placeholder: "mdi:star-four-points-circle",
               fullWidth: true,
             })}
+            ${this._renderIconPickerField("Icono (estado activo)", "icon_active", config.icon_active, {
+              placeholder: "mdi:door-open",
+              fullWidth: true,
+            })}
+            ${this._renderIconPickerField("Icono (estado inactivo)", "icon_inactive", config.icon_inactive, {
+              placeholder: "mdi:door-closed",
+              fullWidth: true,
+            })}
+            <div class="editor-section__hint editor-field--full" style="grid-column: 1 / -1; margin-top: -4px;">
+              ${escapeHtml(
+                this._editorLabel(
+                  "Opcional: icono distinto cuando la insignia está activa o inactiva (interruptores, puertas, ventanas, etc.). Si uno queda vacío, se usa el icono general o el de la entidad.",
+                ),
+              )}
+            </div>
             ${this._renderTextField("Nombre visible", "name", config.name, {
               placeholder: this._editorLabel("Temperatura"),
               fullWidth: true,

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.1";
+const CARD_VERSION = "0.2.2";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -46,7 +46,7 @@ const DEFAULT_CONFIG = {
       background: "color-mix(in srgb, var(--primary-text-color) 5%, transparent)",
       on_color: "var(--info-color, #71c0ff)",
       off_color: "var(--state-inactive-color, color-mix(in srgb, var(--primary-text-color) 55%, transparent))",
-      icon_only_offset_y: "2px",
+      icon_only_offset_y: "0",
     },
     tint: {
       color: "var(--info-color, #71c0ff)",
@@ -884,6 +884,7 @@ class NodaliaInsigniaCard extends HTMLElement {
 
         :host([data-icon-only]) {
           justify-content: center;
+          overflow: visible;
           width: auto;
         }
 
@@ -904,6 +905,10 @@ class NodaliaInsigniaCard extends HTMLElement {
           position: relative;
           overflow: hidden;
           transition: background 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+        }
+
+        .insignia-card.insignia-card--icon-only {
+          overflow: visible;
         }
 
         .insignia-card--icon-only {

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };
@@ -1111,6 +1149,28 @@ class NodaliaInsigniaCard extends HTMLElement {
     return "var(--info-color, #71c0ff)";
   }
 
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
   _onClick(event) {
     const trigger = event
       .composedPath()
@@ -1149,6 +1209,9 @@ class NodaliaInsigniaCard extends HTMLElement {
     }
 
     if (action === "service" && this._config.tap_service) {
+      if (!this._isServiceAllowed(this._config.tap_service)) {
+        return;
+      }
       const [domain, service] = this._config.tap_service.split(".");
       if (domain && service) {
         let serviceData = {};
@@ -1180,10 +1243,14 @@ class NodaliaInsigniaCard extends HTMLElement {
     }
 
     if (action === "url" && this._config.tap_url) {
+      const safeUrl = window.NodaliaUtils?.sanitizeActionUrl(this._config.tap_url, { allowRelative: true });
+      if (!safeUrl) {
+        return;
+      }
       if (this._config.tap_new_tab) {
-        window.open(this._config.tap_url, "_blank", "noopener");
+        window.open(safeUrl, "_blank", "noopener,noreferrer");
       } else {
-        window.location.href = this._config.tap_url;
+        window.location.href = safeUrl;
       }
     }
   }

--- a/nodalia-insignia-card.js
+++ b/nodalia-insignia-card.js
@@ -1,6 +1,6 @@
 const CARD_TAG = "nodalia-insignia-card";
 const EDITOR_TAG = "nodalia-insignia-card-editor";
-const CARD_VERSION = "0.2.6";
+const CARD_VERSION = "0.2.8";
 const HAPTIC_PATTERNS = {
   selection: 8,
   light: 10,
@@ -884,7 +884,9 @@ class NodaliaInsigniaCard extends HTMLElement {
         }
 
         :host([data-icon-only]) {
-          align-self: stretch;
+          /* Same cross-axis behavior as non–icon-only pills (`align-items: center` on row).
+             `stretch` forced full line height and skewed vertical center vs text pills + menu. */
+          align-self: var(--insignia-icon-only-align-self, center);
           box-sizing: border-box;
           display: flex;
           align-items: center;

--- a/nodalia-light-card.js
+++ b/nodalia-light-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-light-card.js
+++ b/nodalia-light-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-light-card";
 const EDITOR_TAG = "nodalia-light-card-editor";
 const CARD_VERSION = "0.7.4";

--- a/nodalia-light-card.js
+++ b/nodalia-light-card.js
@@ -183,71 +183,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -3831,11 +3766,7 @@ class NodaliaLightCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("light."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id => id.startsWith("light."));
   }
 
   _getLightEntityOptions() {
@@ -3948,7 +3879,7 @@ class NodaliaLightCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-media-player.js
+++ b/nodalia-media-player.js
@@ -308,71 +308,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function normalizePowerActionConfig(action) {
   if (!isObject(action)) {
@@ -5248,11 +5183,7 @@ class NodaliaMediaPlayerEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("media_player."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id => id.startsWith("media_player."));
   }
 
   _getEntityOptions(field = "players.0.entity", domains = []) {
@@ -5343,7 +5274,7 @@ class NodaliaMediaPlayerEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-media-player.js
+++ b/nodalia-media-player.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-media-player";
 const EDITOR_TAG = "nodalia-media-player-editor";
 const CARD_VERSION = "0.6.2";

--- a/nodalia-media-player.js
+++ b/nodalia-media-player.js
@@ -1017,6 +1017,29 @@ function getRangeValueFromClientX(slider, clientX) {
   return clamp(nextValue, min, max);
 }
 
+function getSliderDragGeometry(slider) {
+  const rect = slider.getBoundingClientRect();
+  return {
+    left: rect.left,
+    width: rect.width,
+    min: Number(slider.min || 0),
+    max: Number(slider.max || 100),
+    step: slider.step === "any" ? 0 : Number(slider.step || 1),
+  };
+}
+
+function getRangeValueFromGeometry(geometry, currentValue, clientX) {
+  if (!geometry || !Number.isFinite(geometry.width) || geometry.width <= 0) {
+    return Number(currentValue || 0);
+  }
+  const ratio = clamp((clientX - geometry.left) / geometry.width, 0, 1);
+  let nextValue = geometry.min + ((geometry.max - geometry.min) * ratio);
+  if (Number.isFinite(geometry.step) && geometry.step > 0) {
+    nextValue = geometry.min + (Math.round((nextValue - geometry.min) / geometry.step) * geometry.step);
+  }
+  return clamp(nextValue, geometry.min, geometry.max);
+}
+
 function formatDuration(totalSeconds) {
   const safeSeconds = Math.max(0, Math.floor(Number(totalSeconds) || 0));
   const hours = Math.floor(safeSeconds / 3600);
@@ -2591,6 +2614,7 @@ class NodaliaMediaPlayer extends HTMLElement {
     this._activeSliderDrag = {
       pointerId,
       slider,
+      geometry: getSliderDragGeometry(slider),
     };
 
     if (event) {
@@ -2604,7 +2628,7 @@ class NodaliaMediaPlayer extends HTMLElement {
       this._dragFrame = 0;
     }
 
-    const nextValue = getRangeValueFromClientX(slider, clientX);
+    const nextValue = getRangeValueFromGeometry(this._activeSliderDrag.geometry, slider.value, clientX);
     slider.value = String(nextValue);
 
     if (slider.dataset.mediaSlider === "volume") {
@@ -2614,7 +2638,7 @@ class NodaliaMediaPlayer extends HTMLElement {
   }
 
   _queueSliderDragUpdate(slider, clientX) {
-    const nextValue = getRangeValueFromClientX(slider, clientX);
+    const nextValue = getRangeValueFromGeometry(this._activeSliderDrag?.geometry, slider.value, clientX);
     slider.value = String(nextValue);
 
     if (slider.dataset.mediaSlider === "volume") {
@@ -2639,7 +2663,7 @@ class NodaliaMediaPlayer extends HTMLElement {
       this._dragFrame = 0;
     }
 
-    const nextValue = getRangeValueFromClientX(drag.slider, clientX);
+    const nextValue = getRangeValueFromGeometry(drag.geometry, drag.slider.value, clientX);
     drag.slider.value = String(nextValue);
     this._skipNextSliderChange = drag.slider;
 

--- a/nodalia-media-player.js
+++ b/nodalia-media-player.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };
@@ -2284,6 +2322,10 @@ class NodaliaMediaPlayer extends HTMLElement {
       return;
     }
 
+    if (!this._isServiceAllowed(action.service)) {
+      return;
+    }
+
     const [domain, service] = String(action.service).split(".");
     if (!domain || !service) {
       return;
@@ -2307,6 +2349,28 @@ class NodaliaMediaPlayer extends HTMLElement {
     this._hass.callService(domain, service, payload);
   }
 
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
   _runActionDefinition(action, fallbackEntityId = "") {
     if (!action || action.action === "none") {
       return;
@@ -2327,13 +2391,13 @@ class NodaliaMediaPlayer extends HTMLElement {
         }
         break;
       case "url": {
-        const url = action.url_path || action.url;
+        const url = window.NodaliaUtils?.sanitizeActionUrl(action.url_path || action.url, { allowRelative: true }) || "";
         if (!url) {
           return;
         }
 
         if (action.new_tab) {
-          window.open(url, "_blank", "noopener");
+          window.open(url, "_blank", "noopener,noreferrer");
         } else {
           window.location.assign(url);
         }

--- a/nodalia-navigation-bar.js
+++ b/nodalia-navigation-bar.js
@@ -360,71 +360,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -4281,85 +4216,27 @@ class NodaliaNavigationBarEditor extends HTMLElement {
     `;
   }
 
-  _copyDatasetToControl(host, control) {
-    Object.entries(host.dataset || {}).forEach(([key, value]) => {
-      if (key === "mountedControl" || key === "value" || key === "placeholder") {
-        return;
-      }
-      control.dataset[key] = value;
+  _mountEntityPicker(host) {
+    window.NodaliaUtils.mountEntityPickerHost(host, {
+      hass: this._hass,
+      field: host.dataset.field || "entity",
+      value: host.dataset.value || "",
+      placeholder: host.dataset.placeholder || "",
+      onShadowInput: this._onShadowInput,
+      onShadowValueChanged: this._onShadowInput,
+      copyDatasetFromHost: true,
     });
   }
 
-  _mountEntityPicker(host) {
-    if (!(host instanceof HTMLElement)) {
-      return;
-    }
-
-    const nextValue = host.dataset.value || "";
-    const placeholder = host.dataset.placeholder || "";
-    let control = null;
-
-    if (customElements.get("ha-entity-picker")) {
-      control = document.createElement("ha-entity-picker");
-      control.allowCustomEntity = true;
-    } else if (customElements.get("ha-selector")) {
-      control = document.createElement("ha-selector");
-      control.selector = { entity: {} };
-    } else {
-      control = document.createElement("input");
-      control.type = "text";
-    }
-
-    this._copyDatasetToControl(host, control);
-
-    if ("hass" in control) {
-      control.hass = this._hass;
-    }
-    if (placeholder && "placeholder" in control) {
-      control.placeholder = placeholder;
-    }
-    if ("value" in control) {
-      control.value = nextValue;
-    }
-    if (control.tagName !== "INPUT") {
-      control.addEventListener("value-changed", this._onShadowInput);
-    }
-
-    host.replaceChildren(control);
-  }
-
   _mountIconPicker(host) {
-    if (!(host instanceof HTMLElement)) {
-      return;
-    }
-
-    const nextValue = host.dataset.value || "";
-    const placeholder = host.dataset.placeholder || "";
-    let control = null;
-
-    if (customElements.get("ha-icon-picker")) {
-      control = document.createElement("ha-icon-picker");
-    } else {
-      control = document.createElement("input");
-      control.type = "text";
-    }
-
-    this._copyDatasetToControl(host, control);
-
-    if ("hass" in control) {
-      control.hass = this._hass;
-    }
-    if (placeholder && "placeholder" in control) {
-      control.placeholder = placeholder;
-    }
-    if ("value" in control) {
-      control.value = nextValue;
-    }
-    if (control.tagName !== "INPUT") {
-      control.addEventListener("value-changed", this._onShadowInput);
-    }
-
-    host.replaceChildren(control);
+    window.NodaliaUtils.mountIconPickerHost(host, {
+      hass: this._hass,
+      value: host.dataset.value || "",
+      placeholder: host.dataset.placeholder || "",
+      onShadowInput: this._onShadowInput,
+      onShadowValueChanged: this._onShadowInput,
+      copyDatasetFromHost: true,
+    });
   }
 
   _prepareEditorConfig(config) {
@@ -4500,7 +4377,7 @@ class NodaliaNavigationBarEditor extends HTMLElement {
     this._restoreFocusState(focusState);
     const merged = mergeConfig(DEFAULT_CONFIG, prepared);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(merged, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(merged, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-navigation-bar.js
+++ b/nodalia-navigation-bar.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-navigation-bar";
 const EDITOR_TAG = "nodalia-navigation-bar-editor";
 const CARD_VERSION = "0.6.5";

--- a/nodalia-navigation-bar.js
+++ b/nodalia-navigation-bar.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };
@@ -1575,12 +1613,100 @@ class NodaliaNavigationBarCard extends HTMLElement {
       return;
     }
 
+    if (!this._isServiceAllowed(action.service)) {
+      return;
+    }
+
     const [domain, service] = String(action.service).split(".");
     if (!domain || !service) {
       return;
     }
 
     this._hass.callService(domain, service, action.service_data || {}, action.target);
+  }
+
+  _isServiceAllowed(serviceValue) {
+    const security = this._config?.security || {};
+    if (security.strict_service_actions !== true) {
+      return true;
+    }
+    const normalizedService = String(serviceValue || "").trim().toLowerCase();
+    if (!normalizedService || !normalizedService.includes(".")) {
+      return false;
+    }
+    const [domain] = normalizedService.split(".");
+    const domains = Array.isArray(security.allowed_service_domains)
+      ? security.allowed_service_domains.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    const services = Array.isArray(security.allowed_services)
+      ? security.allowed_services.map(item => String(item || "").trim().toLowerCase()).filter(Boolean)
+      : [];
+    if (!domains.length && !services.length) {
+      return false;
+    }
+    return services.includes(normalizedService) || domains.includes(domain);
+  }
+
+  _applyRouteRuntimeStyles(visibleRoutes, playDockEntrance) {
+    if (!this.shadowRoot) {
+      return;
+    }
+    visibleRoutes.forEach((route, index) => {
+      const node = this.shadowRoot.querySelector(`.nav-item[data-route-index="${index}"]`);
+      if (!(node instanceof HTMLElement)) {
+        return;
+      }
+      if (playDockEntrance) {
+        node.style.setProperty("--nav-enter-delay", `${Math.min(index * 38, 520)}ms`);
+      }
+      if (route.background) node.style.setProperty("--route-background", route.background);
+      if (route.color) node.style.setProperty("--route-color", route.color);
+      if (route.active_color) node.style.setProperty("--route-active-color", route.active_color);
+      if (route.active_background) node.style.setProperty("--route-active-background", route.active_background);
+      const badge = this._getBadge(route);
+      const badgeNode = node.querySelector(".nav-badge");
+      if (badgeNode instanceof HTMLElement) {
+        if (badge.background) badgeNode.style.setProperty("--badge-background", badge.background);
+        if (badge.color) badgeNode.style.setProperty("--badge-color", badge.color);
+      }
+    });
+  }
+
+  _applyPopupRuntimeStyles() {
+    if (!this.shadowRoot || !this._popupState?.route) {
+      return;
+    }
+    const panel = this.shadowRoot.querySelector(".popup-panel");
+    if (panel instanceof HTMLElement) {
+      const popupItems = this._getPopupItems(this._popupState.route);
+      const popupHasText = popupItems.some(item => Boolean(this._getRouteLabel(item) || item.description));
+      const isCompactPopup = !popupHasText && Number(this._popupState.columns || 1) === 1;
+      panel.style.left = this._popupState.left;
+      panel.style.top = this._popupState.top;
+      panel.style.width = isCompactPopup ? "fit-content" : this._popupState.width;
+      panel.style.setProperty("--popup-columns", String(this._popupState.columns || 1));
+      panel.style.setProperty(
+        "--popup-item-min",
+        this._popupState.itemMinWidth || `calc(${this._config.styles.popup.item_size} + 24px)`,
+      );
+    }
+    const popupItems = this._getPopupItems(this._popupState.route);
+    popupItems.forEach((item, popupIndex) => {
+      const node = this.shadowRoot.querySelector(`.popup-item[data-popup-item-index="${popupIndex}"]`);
+      if (!(node instanceof HTMLElement)) {
+        return;
+      }
+      if (item.background) node.style.setProperty("--popup-route-background", item.background);
+      if (item.color) node.style.setProperty("--popup-route-color", item.color);
+      if (item.active_color) node.style.setProperty("--popup-route-active-color", item.active_color);
+      if (item.active_background) node.style.setProperty("--popup-route-active-background", item.active_background);
+      const badge = this._getBadge(item);
+      const badgeNode = node.querySelector(".nav-badge");
+      if (badgeNode instanceof HTMLElement) {
+        if (badge.background) badgeNode.style.setProperty("--badge-background", badge.background);
+        if (badge.color) badgeNode.style.setProperty("--badge-color", badge.color);
+      }
+    });
   }
 
   _closePopup(shouldRender = true) {
@@ -2557,13 +2683,13 @@ class NodaliaNavigationBarCard extends HTMLElement {
         this._openPopup(route, options.anchorElement);
         return;
       case "url": {
-        const url = action.url_path || action.url || route.url || route.path;
+        const url = window.NodaliaUtils?.sanitizeActionUrl(action.url_path || action.url || route.url || route.path, { allowRelative: true }) || "";
         if (!url) {
           return;
         }
 
         if (action.new_tab) {
-          window.open(url, "_blank", "noopener");
+          window.open(url, "_blank", "noopener,noreferrer");
         } else {
           window.location.assign(url);
         }
@@ -2627,22 +2753,12 @@ class NodaliaNavigationBarCard extends HTMLElement {
         const hasDescription = Boolean(item.description);
         const isIconOnly = !hasLabel && !hasDescription;
         const ariaLabel = label || item.description || item.path || `Popup ${popupIndex + 1}`;
-        const itemStyle = [
-          item.background ? `--popup-route-background:${item.background};` : "",
-          item.color ? `--popup-route-color:${item.color};` : "",
-          item.active_color ? `--popup-route-active-color:${item.active_color};` : "",
-          item.active_background ? `--popup-route-active-background:${item.active_background};` : "",
-        ]
-          .filter(Boolean)
-          .join("");
-
         return `
           <button
             class="popup-item ${isActive ? "active" : ""} ${isIconOnly ? "icon-only" : ""}"
             type="button"
             data-popup-route-index="${this._popupState.routeIndex}"
             data-popup-item-index="${popupIndex}"
-            style="${itemStyle}"
             aria-label="${escapeHtml(ariaLabel)}"
           >
             <span class="popup-item__icon-wrap">
@@ -2651,7 +2767,6 @@ class NodaliaNavigationBarCard extends HTMLElement {
                 badge
                   ? `<span
                       class="nav-badge"
-                      style="--badge-background:${badge.background};--badge-color:${badge.color};"
                     >${escapeHtml(badge.content)}</span>`
                   : ""
               }
@@ -2683,7 +2798,6 @@ class NodaliaNavigationBarCard extends HTMLElement {
       <div class="popup-backdrop" data-popup-close="true"></div>
       <div
         class="popup-panel popup-panel--${this._popupState.direction} popup-panel--layout-${this._popupState.layout || "auto"} ${popupHasText ? "popup-panel--with-text" : "popup-panel--icon-only"} ${isCompactPopup ? "popup-panel--compact" : ""}"
-        style="left:${this._popupState.left};top:${this._popupState.top};width:${isCompactPopup ? "fit-content" : this._popupState.width};--popup-columns:${this._popupState.columns || 1};--popup-item-min:${this._popupState.itemMinWidth || `calc(${this._config.styles.popup.item_size} + 24px)`};"
       >
         <div class="popup-items">
           ${popupMarkup}
@@ -3177,15 +3291,6 @@ class NodaliaNavigationBarCard extends HTMLElement {
               const isActive = this._isRouteActive(route, currentPath);
               const badge = this._getBadge(route);
               const label = this._getRouteLabel(route);
-              const routeStyle = [
-                playDockEntrance ? `--nav-enter-delay:${Math.min(index * 38, 520)}ms;` : "",
-                route.background ? `--route-background:${route.background};` : "",
-                route.color ? `--route-color:${route.color};` : "",
-                route.active_color ? `--route-active-color:${route.active_color};` : "",
-                route.active_background ? `--route-active-background:${route.active_background};` : "",
-              ]
-                .filter(Boolean)
-                .join("");
               const hasPopup = this._getPopupItems(route).length > 0;
 
               return `
@@ -3193,7 +3298,6 @@ class NodaliaNavigationBarCard extends HTMLElement {
                   class="nav-item ${isActive ? "active" : ""} ${hasPopup ? "has-popup" : ""}${playDockEntrance ? " nav-item--entering" : ""}"
                   data-route-index="${index}"
                   type="button"
-                  style="${routeStyle}"
                   aria-label="${escapeHtml(label || route.path || `Route ${index + 1}`)}"
                 >
                   <span class="nav-icon-wrap">
@@ -3202,7 +3306,6 @@ class NodaliaNavigationBarCard extends HTMLElement {
                       badge
                         ? `<span
                             class="nav-badge"
-                            style="--badge-background:${badge.background};--badge-color:${badge.color};"
                           >${escapeHtml(badge.content)}</span>`
                         : ""
                     }
@@ -4489,6 +4592,9 @@ class NodaliaNavigationBarCard extends HTMLElement {
       ${popupMarkup}
       ${mediaBrowserMarkup}
     `;
+
+    this._applyRouteRuntimeStyles(visibleRoutes, playDockEntrance);
+    this._applyPopupRuntimeStyles();
 
     if (this._popupState) {
       this._schedulePopupPositionSync();

--- a/nodalia-person-card.js
+++ b/nodalia-person-card.js
@@ -154,71 +154,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -1335,11 +1270,12 @@ class NodaliaPersonCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("person.") || entityId.startsWith("device_tracker."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(
+      hass,
+      this._config?.language,
+      id =>
+        id.startsWith("person.") || id.startsWith("device_tracker."),
+    );
   }
 
   _watchEditorControlTag(tagName) {
@@ -1489,7 +1425,7 @@ class NodaliaPersonCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-person-card.js
+++ b/nodalia-person-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-person-card";
 const EDITOR_TAG = "nodalia-person-card-editor";
 const CARD_VERSION = "0.9.1";

--- a/nodalia-person-card.js
+++ b/nodalia-person-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-power-flow-card.js
+++ b/nodalia-power-flow-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-power-flow-card";
 const EDITOR_TAG = "nodalia-power-flow-card-editor";
 const CARD_VERSION = "0.16.13";

--- a/nodalia-power-flow-card.js
+++ b/nodalia-power-flow-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-power-flow-card.js
+++ b/nodalia-power-flow-card.js
@@ -236,71 +236,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -2971,14 +2906,9 @@ class NodaliaPowerFlowCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass) {
-    if (!hass?.states) {
-      return "";
-    }
-
-    return Object.keys(hass.states)
-      .filter(entityId => entityId.startsWith("sensor.") || entityId.startsWith("number.") || entityId.startsWith("input_number."))
-      .sort((left, right) => left.localeCompare(right, "es"))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id =>
+      id.startsWith("sensor.") || id.startsWith("number.") || id.startsWith("input_number."),
+    );
   }
 
   _captureFocusState() {
@@ -3055,7 +2985,7 @@ class NodaliaPowerFlowCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 
@@ -3622,11 +3552,9 @@ class NodaliaPowerFlowCardVisualEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("sensor.") || entityId.startsWith("number.") || entityId.startsWith("input_number."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(hass, this._config?.language, id =>
+      id.startsWith("sensor.") || id.startsWith("number.") || id.startsWith("input_number."),
+    );
   }
 
   _watchEditorControlTag(tagName) {
@@ -3772,7 +3700,7 @@ class NodaliaPowerFlowCardVisualEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-utils.js
+++ b/nodalia-utils.js
@@ -3,7 +3,21 @@
  * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
  */
 (function initNodaliaUtils() {
-  if (typeof window !== "undefined" && window.NodaliaUtils?.stripEqualToDefaults && window.NodaliaUtils?.deepEqual) {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
     return;
   }
 
@@ -98,21 +112,31 @@
   }
 
   /**
-   * Count entities matching predicate(entityId); same locale prefix as editorStatesSignature.
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
    */
   function editorFilteredStatesSignature(hass, language, predicate) {
     const states = hass?.states || {};
-    let n = 0;
+    const rows = [];
     for (const id of Object.keys(states)) {
-      if (predicate(id)) {
-        n += 1;
+      if (!predicate(id)) {
+        continue;
       }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
     }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
     const tag =
       typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
         ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
         : "";
-    return `${tag}|${n}`;
+    return `${tag}|${rows.join("|")}`;
   }
 
   function copyDatasetExcept(control, host, skipKeys) {

--- a/nodalia-utils.js
+++ b/nodalia-utils.js
@@ -125,6 +125,30 @@
     });
   }
 
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
   /**
    * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
    */
@@ -175,7 +199,7 @@
 
       control.dataset.field = field;
       if (copyDatasetFromHost) {
-        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder"]);
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
       }
 
       if ("hass" in control) {
@@ -188,10 +212,14 @@
         control.placeholder = placeholder;
       }
 
-      if (control.tagName === "INPUT") {
-        control.addEventListener("change", onShadowInput);
-      } else {
-        control.addEventListener("value-changed", onShadowValueChanged || onShadowInput);
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
       }
 
       host.appendChild(control);
@@ -200,6 +228,7 @@
 
     control.dataset.field = field;
     control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
     if ("hass" in control) {
       control.hass = hass;
     }
@@ -244,7 +273,7 @@
       }
 
       if (copyDatasetFromHost) {
-        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder"]);
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
       }
 
       if ("hass" in control) {
@@ -257,16 +286,21 @@
         control.value = nextValue;
       }
 
-      if (control.tagName === "INPUT") {
-        control.addEventListener("change", onShadowInput);
-      } else {
-        control.addEventListener("value-changed", onShadowValueChanged || onShadowInput);
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
       }
 
       host.appendChild(control);
       return;
     }
 
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
     if ("hass" in control) {
       control.hass = hass;
     }

--- a/nodalia-utils.js
+++ b/nodalia-utils.js
@@ -10,6 +10,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -133,6 +134,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -339,6 +376,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-utils.js
+++ b/nodalia-utils.js
@@ -99,19 +99,6 @@
   }
 
   /**
-   * Cheap signature when the editor only needs to know if hass/stale registry size changed.
-   * Includes locale tag so language switches still re-render translated labels.
-   */
-  function editorStatesSignature(hass, language) {
-    const count = Object.keys(hass?.states || {}).length;
-    const tag =
-      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
-        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
-        : "";
-    return `${tag}|${count}`;
-  }
-
-  /**
    * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
    * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
    */
@@ -137,6 +124,15 @@
         ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
         : "";
     return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
   }
 
   function copyDatasetExcept(control, host, skipKeys) {

--- a/nodalia-utils.js
+++ b/nodalia-utils.js
@@ -1,0 +1,295 @@
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  if (typeof window !== "undefined" && window.NodaliaUtils?.stripEqualToDefaults && window.NodaliaUtils?.deepEqual) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Cheap signature when the editor only needs to know if hass/stale registry size changed.
+   * Includes locale tag so language switches still re-render translated labels.
+   */
+  function editorStatesSignature(hass, language) {
+    const count = Object.keys(hass?.states || {}).length;
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${count}`;
+  }
+
+  /**
+   * Count entities matching predicate(entityId); same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    let n = 0;
+    for (const id of Object.keys(states)) {
+      if (predicate(id)) {
+        n += 1;
+      }
+    }
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${n}`;
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      if (control.tagName === "INPUT") {
+        control.addEventListener("change", onShadowInput);
+      } else {
+        control.addEventListener("value-changed", onShadowValueChanged || onShadowInput);
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      if (control.tagName === "INPUT") {
+        control.addEventListener("change", onShadowInput);
+      } else {
+        control.addEventListener("value-changed", onShadowValueChanged || onShadowInput);
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();

--- a/nodalia-vacuum-card.js
+++ b/nodalia-vacuum-card.js
@@ -237,71 +237,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -3266,15 +3201,12 @@ class NodaliaVacuumCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => (
-        entityId.startsWith("vacuum.")
-        || entityId.startsWith("select.")
-        || entityId.startsWith("sensor.")
-      ))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(
+      hass,
+      this._config?.language,
+      id =>
+        id.startsWith("vacuum.") || id.startsWith("select.") || id.startsWith("sensor."),
+    );
   }
 
   _buildEntityOptions(filterFn, currentValue = "") {
@@ -3407,7 +3339,7 @@ class NodaliaVacuumCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/nodalia-vacuum-card.js
+++ b/nodalia-vacuum-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-vacuum-card.js
+++ b/nodalia-vacuum-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-vacuum-card";
 const EDITOR_TAG = "nodalia-vacuum-card-editor";
 const CARD_VERSION = "0.6.2";

--- a/nodalia-weather-card.js
+++ b/nodalia-weather-card.js
@@ -1,3 +1,358 @@
+// <nodalia-standalone-utils>
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+/**
+ * Shared helpers for Nodalia cards (deep equality, config stripping, editor mounts).
+ * Loaded early in nodalia-cards.js bundle; exposed as window.NodaliaUtils.
+ */
+(function initNodaliaUtils() {
+  const REQUIRED_API_KEYS = [
+    "isObject",
+    "deepClone",
+    "deepEqual",
+    "stripEqualToDefaults",
+    "editorStatesSignature",
+    "editorFilteredStatesSignature",
+    "mountEntityPickerHost",
+    "mountIconPickerHost",
+  ];
+  const existing = typeof window !== "undefined" ? window.NodaliaUtils : null;
+  if (
+    existing &&
+    REQUIRED_API_KEYS.every(key => typeof existing[key] === "function")
+  ) {
+    return;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function deepClone(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function deepEqual(a, b) {
+    if (Object.is(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return a === b;
+    }
+    if (typeof a !== typeof b) {
+      return false;
+    }
+    if (typeof a !== "object") {
+      return false;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value, index) => deepEqual(value, b[index]));
+    }
+    if (Array.isArray(b)) {
+      return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    return keysA.every(key => deepEqual(a[key], b[key]));
+  }
+
+  function stripEqualToDefaults(config, defaults) {
+    if (defaults === undefined || defaults === null) {
+      return deepClone(config);
+    }
+    if (config === undefined || config === null) {
+      return undefined;
+    }
+    if (Array.isArray(config)) {
+      return deepEqual(config, defaults) ? undefined : deepClone(config);
+    }
+    if (isObject(config) && isObject(defaults)) {
+      const out = {};
+      for (const key of Object.keys(config)) {
+        const cv = config[key];
+        const dv = defaults[key];
+        if (!(key in defaults)) {
+          out[key] = deepClone(cv);
+          continue;
+        }
+        if (deepEqual(cv, dv)) {
+          continue;
+        }
+        if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
+          const stripped = stripEqualToDefaults(cv, dv);
+          if (stripped !== undefined) {
+            out[key] = stripped;
+          }
+        } else {
+          out[key] = deepClone(cv);
+        }
+      }
+      return Object.keys(out).length ? out : undefined;
+    }
+    return deepEqual(config, defaults) ? undefined : config;
+  }
+
+  /**
+   * Signature for entities matching predicate(entityId): id + friendly_name + icon per row,
+   * so picker labels update when attributes change. Same locale prefix as editorStatesSignature.
+   */
+  function editorFilteredStatesSignature(hass, language, predicate) {
+    const states = hass?.states || {};
+    const rows = [];
+    for (const id of Object.keys(states)) {
+      if (!predicate(id)) {
+        continue;
+      }
+      const state = states[id];
+      rows.push(
+        `${id}:${String(state?.attributes?.friendly_name ?? "")}:${String(state?.attributes?.icon ?? "")}`,
+      );
+    }
+    rows.sort((left, right) => {
+      const idLeft = left.split(":")[0];
+      const idRight = right.split(":")[0];
+      return idLeft.localeCompare(idRight, "es", { sensitivity: "base" });
+    });
+    const tag =
+      typeof window !== "undefined" && window.NodaliaI18n && typeof hass !== "undefined"
+        ? window.NodaliaI18n.localeTag(window.NodaliaI18n.resolveLanguage(hass, language))
+        : "";
+    return `${tag}|${rows.join("|")}`;
+  }
+
+  /**
+   * Full hass.states signature: every entity as id + friendly_name + icon (sorted by id),
+   * plus locale tag — same shape as editorFilteredStatesSignature. Editors that list entities
+   * re-render when labels or icons change, not only when the entity count changes.
+   */
+  function editorStatesSignature(hass, language) {
+    return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  function copyDatasetExcept(control, host, skipKeys) {
+    const skip = new Set(skipKeys || []);
+    Object.entries(host.dataset || {}).forEach(([key, value]) => {
+      if (skip.has(key)) {
+        return;
+      }
+      control.dataset[key] = value;
+    });
+  }
+
+  /** Latest callbacks for reused picker controls (listeners call into this). */
+  const pickerCallbackState = new WeakMap();
+  const pickerControlsWithListeners = new WeakSet();
+
+  function dispatchPickerChange(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (s && typeof s.onShadowInput === "function") {
+      s.onShadowInput(ev);
+    }
+  }
+
+  function dispatchPickerValueChanged(ev) {
+    const control = ev.currentTarget;
+    const s = pickerCallbackState.get(control);
+    if (!s) {
+      return;
+    }
+    const fn = s.onShadowValueChanged || s.onShadowInput;
+    if (typeof fn === "function") {
+      fn(ev);
+    }
+  }
+
+  /**
+   * Mount or update ha-entity-picker / ha-selector / text input without recreating each render.
+   */
+  function mountEntityPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const field = options.field || host.dataset.field || "entity";
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder =
+      options.placeholder !== undefined ? String(options.placeholder) : String(host.dataset.placeholder || "");
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const usePicker = typeof customElements !== "undefined" && customElements.get("ha-entity-picker");
+    const useSelector = typeof customElements !== "undefined" && customElements.get("ha-selector");
+
+    let desired = "input";
+    if (usePicker) {
+      desired = "picker";
+    } else if (useSelector) {
+      desired = "selector";
+    }
+
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control &&
+      ((desired === "picker" && tag === "HA-ENTITY-PICKER")
+        || (desired === "selector" && tag === "HA-SELECTOR")
+        || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (usePicker) {
+        control = document.createElement("ha-entity-picker");
+        control.allowCustomEntity = true;
+      } else if (useSelector) {
+        control = document.createElement("ha-selector");
+        control.selector = { entity: {} };
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      control.dataset.field = field;
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    control.dataset.field = field;
+    control.dataset.value = nextValue;
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  /**
+   * Mount or update ha-icon-picker / text input without recreating each render.
+   */
+  function mountIconPickerHost(host, options) {
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const hass = options.hass;
+    const nextValue = options.value !== undefined ? String(options.value) : String(host.dataset.value || "");
+    const placeholder = options.placeholder !== undefined ? options.placeholder : host.dataset.placeholder || "";
+    const onShadowInput = options.onShadowInput;
+    const onShadowValueChanged = options.onShadowValueChanged;
+    const copyDatasetFromHost = options.copyDatasetFromHost !== false;
+
+    const useIconPicker = typeof customElements !== "undefined" && customElements.get("ha-icon-picker");
+
+    let desired = useIconPicker ? "icon" : "input";
+    let control = host.firstElementChild;
+    const tag = control?.tagName || "";
+    const matches =
+      control && ((desired === "icon" && tag === "HA-ICON-PICKER") || (desired === "input" && tag === "INPUT"));
+
+    if (!matches) {
+      host.replaceChildren();
+      if (useIconPicker) {
+        control = document.createElement("ha-icon-picker");
+      } else {
+        control = document.createElement("input");
+        control.type = "text";
+      }
+
+      if (copyDatasetFromHost) {
+        copyDatasetExcept(control, host, ["mountedControl", "value", "placeholder", "field"]);
+      }
+
+      if ("hass" in control) {
+        control.hass = hass;
+      }
+      if (placeholder && "placeholder" in control) {
+        control.placeholder = placeholder;
+      }
+      if ("value" in control) {
+        control.value = nextValue;
+      }
+
+      pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+      if (!pickerControlsWithListeners.has(control)) {
+        pickerControlsWithListeners.add(control);
+        if (control.tagName === "INPUT") {
+          control.addEventListener("change", dispatchPickerChange);
+        } else {
+          control.addEventListener("value-changed", dispatchPickerValueChanged);
+        }
+      }
+
+      host.appendChild(control);
+      return;
+    }
+
+    pickerCallbackState.set(control, { onShadowInput, onShadowValueChanged });
+    if ("hass" in control) {
+      control.hass = hass;
+    }
+    if (placeholder && "placeholder" in control) {
+      control.placeholder = placeholder;
+    }
+    if ("value" in control && control.value !== nextValue) {
+      control.value = nextValue;
+    }
+  }
+
+  const api = {
+    isObject,
+    deepClone,
+    deepEqual,
+    stripEqualToDefaults,
+    editorStatesSignature,
+    editorFilteredStatesSignature,
+    mountEntityPickerHost,
+    mountIconPickerHost,
+  };
+
+  if (typeof window !== "undefined") {
+    window.NodaliaUtils = api;
+  }
+})();
+
+// </nodalia-standalone-utils>
+
 const CARD_TAG = "nodalia-weather-card";
 const EDITOR_TAG = "nodalia-weather-card-editor";
 const CARD_VERSION = "0.12.3";

--- a/nodalia-weather-card.js
+++ b/nodalia-weather-card.js
@@ -13,6 +13,7 @@
     "stripEqualToDefaults",
     "editorStatesSignature",
     "editorFilteredStatesSignature",
+    "sanitizeActionUrl",
     "mountEntityPickerHost",
     "mountIconPickerHost",
   ];
@@ -136,6 +137,42 @@
    */
   function editorStatesSignature(hass, language) {
     return editorFilteredStatesSignature(hass, language, () => true);
+  }
+
+  /**
+   * Normalize and validate user-provided action URLs.
+   * Allows http/https and same-origin relative paths by default.
+   */
+  function sanitizeActionUrl(value, options = {}) {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+    const allowRelative = options.allowRelative !== false;
+    const allowHash = options.allowHash === true;
+    if (allowHash && raw.startsWith("#")) {
+      return raw;
+    }
+    if (allowRelative && (/^\/(?!\/)/.test(raw) || raw.startsWith("./") || raw.startsWith("../"))) {
+      return raw;
+    }
+    try {
+      const base =
+        typeof window !== "undefined" && window.location
+          ? window.location.origin
+          : "https://example.invalid";
+      const parsed = new URL(raw, base);
+      const protocol = String(parsed.protocol || "").toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        return "";
+      }
+      if (allowRelative && typeof window !== "undefined" && window.location && parsed.origin === window.location.origin) {
+        return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return "";
+    }
   }
 
   function copyDatasetExcept(control, host, skipKeys) {
@@ -342,6 +379,7 @@
     stripEqualToDefaults,
     editorStatesSignature,
     editorFilteredStatesSignature,
+    sanitizeActionUrl,
     mountEntityPickerHost,
     mountIconPickerHost,
   };

--- a/nodalia-weather-card.js
+++ b/nodalia-weather-card.js
@@ -164,71 +164,6 @@ function compactConfig(value) {
   return value;
 }
 
-function deepEqual(a, b) {
-  if (Object.is(a, b)) {
-    return true;
-  }
-  if (a == null || b == null) {
-    return a === b;
-  }
-  if (typeof a !== typeof b) {
-    return false;
-  }
-  if (typeof a !== "object") {
-    return false;
-  }
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((value, index) => deepEqual(value, b[index]));
-  }
-  if (Array.isArray(b)) {
-    return false;
-  }
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-  return keysA.every(key => deepEqual(a[key], b[key]));
-}
-
-function stripEqualToDefaults(config, defaults) {
-  if (defaults === undefined || defaults === null) {
-    return deepClone(config);
-  }
-  if (config === undefined || config === null) {
-    return undefined;
-  }
-  if (Array.isArray(config)) {
-    return deepEqual(config, defaults) ? undefined : deepClone(config);
-  }
-  if (isObject(config) && isObject(defaults)) {
-    const out = {};
-    for (const key of Object.keys(config)) {
-      const cv = config[key];
-      const dv = defaults[key];
-      if (!(key in defaults)) {
-        out[key] = deepClone(cv);
-        continue;
-      }
-      if (deepEqual(cv, dv)) {
-        continue;
-      }
-      if (isObject(cv) && !Array.isArray(cv) && isObject(dv) && !Array.isArray(dv)) {
-        const stripped = stripEqualToDefaults(cv, dv);
-        if (stripped !== undefined) {
-          out[key] = stripped;
-        }
-      } else {
-        out[key] = deepClone(cv);
-      }
-    }
-    return Object.keys(out).length ? out : undefined;
-  }
-  return deepEqual(config, defaults) ? undefined : config;
-}
 
 function setByPath(target, path, value) {
   const parts = path.split(".");
@@ -3114,11 +3049,12 @@ class NodaliaWeatherCardEditor extends HTMLElement {
   }
 
   _getEntityOptionsSignature(hass = this._hass) {
-    return Object.entries(hass?.states || {})
-      .filter(([entityId]) => entityId.startsWith("weather.") || entityId.startsWith("binary_sensor."))
-      .map(([entityId, state]) => `${entityId}:${String(state?.attributes?.friendly_name || "")}:${String(state?.attributes?.icon || "")}`)
-      .sort((left, right) => left.localeCompare(right, "es", { sensitivity: "base" }))
-      .join("|");
+    return window.NodaliaUtils.editorFilteredStatesSignature(
+      hass,
+      this._config?.language,
+      id =>
+        id.startsWith("weather.") || id.startsWith("binary_sensor."),
+    );
   }
 
   _watchEditorControlTag(tagName) {
@@ -3265,7 +3201,7 @@ class NodaliaWeatherCardEditor extends HTMLElement {
     this._render();
     this._restoreFocusState(focusState);
     fireEvent(this, "config-changed", {
-      config: compactConfig(stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
+      config: compactConfig(window.NodaliaUtils.stripEqualToDefaults(nextConfig, DEFAULT_CONFIG) ?? {}),
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.12",
+  "version": "0.5.0-alpha.13",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.9",
+  "version": "0.5.0-alpha.10",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.4",
+  "version": "0.5.0-alpha.5",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.1",
+  "version": "0.5.0-alpha.2",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.5",
+  "version": "0.5.0-alpha.6",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.11",
+  "version": "0.5.0-alpha.12",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.3",
+  "version": "0.5.0-alpha.4",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.16",
+  "version": "0.5.0",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.8",
+  "version": "0.5.0-alpha.9",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",
   "scripts": {
-    "bundle": "node scripts/build-bundle.mjs"
+    "sync-standalone-embed": "node scripts/sync-standalone-embed.mjs",
+    "bundle": "node scripts/sync-standalone-embed.mjs && node scripts/build-bundle.mjs"
   },
   "files": [
     "nodalia-i18n.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.13",
+  "version": "0.5.0-alpha.14",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.7",
+  "version": "0.5.0-alpha.8",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.2",
+  "version": "0.5.0-alpha.3",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.10",
+  "version": "0.5.0-alpha.11",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.4.0",
+  "version": "0.5.0-alpha.1",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",
@@ -10,6 +10,7 @@
   "files": [
     "nodalia-i18n.js",
     "nodalia-editor-ui.js",
+    "nodalia-utils.js",
     "nodalia-bubble-contrast.js",
     "nodalia-cards.js",
     "nodalia-navigation-bar.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.15",
+  "version": "0.5.0-alpha.16",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.6",
+  "version": "0.5.0-alpha.7",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodalia-cards",
-  "version": "0.5.0-alpha.14",
+  "version": "0.5.0-alpha.15",
   "private": false,
   "type": "module",
   "description": "Suite de tarjetas personalizadas de Home Assistant para Nodalia.",

--- a/scripts/build-bundle.mjs
+++ b/scripts/build-bundle.mjs
@@ -7,6 +7,23 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.join(__dirname, "..");
 const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
 
+const STANDALONE_UTILS_START = "// <nodalia-standalone-utils>";
+const STANDALONE_UTILS_END = "// </nodalia-standalone-utils>";
+
+/** Strip inlined nodalia-utils copy used for standalone card scripts (see scripts/sync-standalone-embed.mjs). */
+function stripStandaloneUtilsEmbed(source) {
+  const i0 = source.indexOf(STANDALONE_UTILS_START);
+  if (i0 === -1) {
+    return source;
+  }
+  const i1 = source.indexOf(STANDALONE_UTILS_END, i0);
+  if (i1 === -1) {
+    throw new Error(`${STANDALONE_UTILS_START} without ${STANDALONE_UTILS_END} in bundled part`);
+  }
+  const tail = source.slice(i1 + STANDALONE_UTILS_END.length).replace(/^\s*\n/, "");
+  return source.slice(0, i0) + tail;
+}
+
 const parts = [
   "nodalia-i18n.js",
   "nodalia-editor-ui.js",
@@ -34,7 +51,7 @@ const parts = [
 let body = "";
 for (const name of parts) {
   body += "{\n";
-  body += fs.readFileSync(path.join(root, name), "utf8");
+  body += stripStandaloneUtilsEmbed(fs.readFileSync(path.join(root, name), "utf8"));
   body += "\n}\n";
 }
 

--- a/scripts/build-bundle.mjs
+++ b/scripts/build-bundle.mjs
@@ -10,6 +10,7 @@ const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"))
 const parts = [
   "nodalia-i18n.js",
   "nodalia-editor-ui.js",
+  "nodalia-utils.js",
   "nodalia-bubble-contrast.js",
   "nodalia-navigation-bar.js",
   "nodalia-media-player.js",

--- a/scripts/editor-source-strings.json
+++ b/scripts/editor-source-strings.json
@@ -490,5 +490,22 @@
   "__T__:Respuesta háptica",
   "__T__:Rutas",
   "__T__:Series",
-  "__T__:Visibilidad"
+  "__T__:Visibilidad",
+  "Insignia",
+  "Chip compacto para la barra de insignias: entidad, icono y texto opcionales.",
+  "Vibración al pulsar la insignia (si el dispositivo lo permite).",
+  "Acción al pulsar",
+  "Qué ocurre al tocar la insignia.",
+  "Apariencia",
+  "Tamaños, colores del icono y tinte de la burbuja.",
+  "Mostrar detalles de estilo",
+  "Ocultar detalles de estilo",
+  "Subtitulo",
+  "Subtítulo",
+  "Posicion",
+  "Posición",
+  "Reproductor",
+  "Principal",
+  "Mostrar ajustes de animacion",
+  "Ocultar ajustes de animacion"
 ]

--- a/scripts/gen-editor-ui.mjs
+++ b/scripts/gen-editor-ui.mjs
@@ -1617,7 +1617,7 @@ const out = `/* eslint-disable max-len */
     substitutions.forEach(([pattern, replacement]) => {
       out = out.replace(pattern, (match, ...rest) => {
         const groups = rest.slice(0, -2);
-        const expanded = String(replacement).replace(/\$(\d+)/g, (_, groupIndexRaw) => {
+        const expanded = String(replacement).replace(/\\$(\\d+)/g, (_, groupIndexRaw) => {
           const groupIndex = Number(groupIndexRaw) - 1;
           return groups[groupIndex] ?? "";
         });
@@ -1626,7 +1626,7 @@ const out = `/* eslint-disable max-len */
     });
 
     // Clean up legacy literal replacement artifacts left by earlier generator versions.
-    out = out.replace(/\$(\d+)/g, "");
+    out = out.replace(/\\$(\\d+)/g, "");
 
     return out;
   }

--- a/scripts/gen-editor-ui.mjs
+++ b/scripts/gen-editor-ui.mjs
@@ -1625,6 +1625,9 @@ const out = `/* eslint-disable max-len */
       });
     });
 
+    // Clean up legacy literal replacement artifacts left by earlier generator versions.
+    out = out.replace(/\$(\d+)/g, "");
+
     return out;
   }
 

--- a/scripts/gen-editor-ui.mjs
+++ b/scripts/gen-editor-ui.mjs
@@ -1615,7 +1615,14 @@ const out = `/* eslint-disable max-len */
     ];
 
     substitutions.forEach(([pattern, replacement]) => {
-      out = out.replace(pattern, match => withMatchCase(match, replacement));
+      out = out.replace(pattern, (match, ...rest) => {
+        const groups = rest.slice(0, -2);
+        const expanded = String(replacement).replace(/\$(\d+)/g, (_, groupIndexRaw) => {
+          const groupIndex = Number(groupIndexRaw) - 1;
+          return groups[groupIndex] ?? "";
+        });
+        return withMatchCase(match, expanded);
+      });
     });
 
     return out;

--- a/scripts/sync-standalone-embed.mjs
+++ b/scripts/sync-standalone-embed.mjs
@@ -1,0 +1,82 @@
+/**
+ * Inlines nodalia-utils.js at the top of each card that depends on window.NodaliaUtils,
+ * so a single Lovelace resource (e.g. nodalia-entity-card.js) works without loading
+ * nodalia-utils.js separately. The block is stripped by scripts/build-bundle.mjs when
+ * building nodalia-cards.js. Regenerate after editing nodalia-utils.js:
+ *   node scripts/sync-standalone-embed.mjs
+ */
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, "..");
+
+const START = "// <nodalia-standalone-utils>";
+const END = "// </nodalia-standalone-utils>";
+
+const FILES = [
+  "nodalia-navigation-bar.js",
+  "nodalia-media-player.js",
+  "nodalia-light-card.js",
+  "nodalia-fan-card.js",
+  "nodalia-humidifier-card.js",
+  "nodalia-circular-gauge-card.js",
+  "nodalia-graph-card.js",
+  "nodalia-power-flow-card.js",
+  "nodalia-climate-card.js",
+  "nodalia-alarm-panel-card.js",
+  "nodalia-advance-vacuum-card.js",
+  "nodalia-entity-card.js",
+  "nodalia-fav-card.js",
+  "nodalia-insignia-card.js",
+  "nodalia-person-card.js",
+  "nodalia-weather-card.js",
+  "nodalia-vacuum-card.js",
+];
+
+function stripEmbed(content) {
+  const i0 = content.indexOf(START);
+  if (i0 === -1) {
+    return content;
+  }
+  const i1 = content.indexOf(END, i0);
+  if (i1 === -1) {
+    throw new Error(`${START} without ${END}`);
+  }
+  const after = content.slice(i1 + END.length);
+  // Remove every leading newline after END so round-trip matches wrapEmbed's trailing newlines.
+  const rest = after.replace(/^\n+/, "");
+  return content.slice(0, i0) + rest;
+}
+
+function wrapEmbed(utilsSrc) {
+  return `${START}
+// Inlined for standalone Lovelace resources (single JS file). Stripped when building nodalia-cards.js.
+// Source of truth: nodalia-utils.js — regenerate: node scripts/sync-standalone-embed.mjs
+${utilsSrc}
+${END}
+
+`;
+}
+
+const utilsSrc = fs.readFileSync(path.join(root, "nodalia-utils.js"), "utf8");
+const embed = wrapEmbed(utilsSrc);
+
+function normalizeNewlines(s) {
+  return s.replace(/\r\n/g, "\n");
+}
+
+let updated = 0;
+for (const name of FILES) {
+  const filePath = path.join(root, name);
+  const beforeFull = fs.readFileSync(filePath, "utf8");
+  const stripped = stripEmbed(beforeFull);
+  const next = embed + stripped;
+  if (normalizeNewlines(next) !== normalizeNewlines(beforeFull)) {
+    fs.writeFileSync(filePath, next);
+    updated += 1;
+  }
+}
+
+console.log(`Standalone utils embed: updated ${updated} file(s).`);


### PR DESCRIPTION
## [0.5.0] - 2026-05-06

First stable release on the **`0.5.x`** line (**branch `main`**). This version consolidates all validated work from the **`0.5.0-alpha.*`** cycle into a production-ready bundle aimed at smoother interaction, stronger hardening, better editor UX and broader translation coverage.

### Security hardening

- Added shared **`sanitizeActionUrl()`** and applied it across URL action sinks to block unsafe schemes and normalize relative/same-origin navigation.
- Standardized new-tab actions to **`noopener,noreferrer`** to reduce tabnabbing/referrer leakage risks.
- Hardened service actions with optional strict mode and allowlists (**domains/services**) to reduce accidental abuse in action configs.
- Removed dynamic inline style string interpolation in critical runtime paths (notably Navigation Bar route/popup styles), applying safe runtime style properties instead.
- Added render-boundary CSS sanitization for user-configurable styles in cards with dynamic style templates (including Insignia and Circular Gauge paths), with safe fallback behavior.

### Performance and fluency

- Improved Graph hover fluidity with **`requestAnimationFrame`** coalescing and reduced per-move work under heavy pointer movement.
- Fixed Graph tooltip lifecycle for stable tracking while moving the pointer (without waiting for stationary hover), with robust leave/close behavior.
- Reduced drag overhead in interactive controls by caching geometry during slider drags and minimizing repeated layout reads.
- Smoothed Climate dial interaction by coalescing drag updates per frame.
- Kept standalone embedding/bundle sync idempotent to avoid unnecessary rewrites and noisy rebuild diffs.

### Stability and bug fixes

- Fixed Graph hook alignment issues (marker/guide/popup sync over chart path and viewBox mapping).
- Fixed Graph header layout so icon bubble and title align consistently in the top-left header row.
- Added spacing and layout refinements in Graph value/chips area for better readability in compact and normal views.
- Fixed tooltip edge cases where popups could remain visible after leaving the card.
- Corrected Insignia icon-only sizing/height parity with normal mode and removed clipping/regression cases in strip/scroll layouts.
- Improved async state consistency in Advance Vacuum map actions by preventing overlapping runs and reducing race conditions after awaited service calls.

### Editor and i18n

- Fixed Spanish editor normalization artifacts where labels like **`Mínimo$1`** / **`Máximo$1`** could appear.
- Strengthened editor label normalization and replacement group handling in generated editor UI runtime.
- Expanded editor/source strings and completed additional translation keys across supported locales.
- Maintained bundled language set coverage for cards and visual editors (**es, en, de, fr, it, nl, pt, ru, el, zh, ro**), with graceful fallback behavior for partial trees.

### Developer and tooling

- Refined shared utility behavior for editor entity signatures so label/icon attribute changes trigger expected refreshes (not only entity count changes).
- Kept standalone utility embedding centralized and automatically stripped during bundle build to avoid duplicated runtime code in `nodalia-cards.js`.