### PR TITLE
chore(release): update documentation for version 1.0.1

### DIFF
--- a/CHANGELOG-PRERELEASES.md
+++ b/CHANGELOG-PRERELEASES.md
@@ -2,7 +2,7 @@
 
 This file archives per-build notes for **`1.0.0-alpha.*`** and **`1.0.0-beta.*`**, copied from the main [`CHANGELOG.md`](./CHANGELOG.md) before that document was trimmed for stable releases.
 
-For the consolidated **stable** story, see **`[1.0.0]`** in [`CHANGELOG.md`](./CHANGELOG.md).
+For the consolidated **stable** story, see **`[1.0.0]`** and **`[1.0.1]`** in [`CHANGELOG.md`](./CHANGELOG.md).
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🎨 Nodalia Cards
 
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.1%2B-41BDF5?logo=home-assistant)
-![Latest stable](https://img.shields.io/badge/latest%20stable-1.0.0-2ea043)
+![Latest stable](https://img.shields.io/badge/latest%20stable-1.0.1-2ea043)
 ![Stable](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?label=stable)
 ![Pre-release](https://img.shields.io/github/v/release/danielmigueltejedor/nodalia-cards?include_prereleases&label=pre-release)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
@@ -46,7 +46,9 @@ Animations and interactions in action:
 
 ---
 
-# 🚀 New in 1.0.0
+# 🚀 What’s new in 1.0.x
+
+**Latest stable: `1.0.1`** — installs match **`package.json`** and **`window.__NODALIA_BUNDLE__.pkgVersion`**. The sections below summarize the **`1.0.0`** milestone (first stable on this line); patch notes for **`1.0.1`** are in [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## 🧠 Notifications Card
 
@@ -108,7 +110,7 @@ Highlights:
 
 ## 🌍 Massive i18n Expansion
 
-Nodalia 1.0.0 ships with extensive localization support:
+The **1.0.x** line ships with extensive localization support:
 
 - 🇪🇸 Spanish
 - 🇬🇧 English
@@ -133,7 +135,7 @@ Including:
 
 ## 🎨 Unified Visual System
 
-1.0.0 introduces a much stronger design system:
+The **1.0.0** milestone introduced a much stronger design system:
 
 - Shared visual tokens
 - Unified shadows and surfaces
@@ -298,7 +300,7 @@ JavaScript module
 
 # 🌍 Translations
 
-Nodalia 1.0.0 includes multi-language runtime and visual editor support.
+**1.0.x** includes multi-language runtime and visual editor support.
 
 Supported languages:
 
@@ -320,7 +322,7 @@ Translation improvements are ongoing.
 
 # 🛣️ Roadmap
 
-Future work planned after 1.0.0:
+Future work planned on top of **1.0.x** (after the **1.0.0** milestone):
 
 - Graph Card redesign
 - Power Flow improvements

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ This roadmap is flexible and evolves based on real-world usage, testing, communi
 Current stable release:
 
 ```text
-1.0.0
+1.0.1
 ```
 
 The `1.0.0` cycle transformed Nodalia Cards from a growing collection of custom cards into a much more complete and cohesive frontend ecosystem for Home Assistant.
@@ -31,7 +31,7 @@ The project now includes:
 
 ---
 
-# 🎯 Current focus (post-1.0.0)
+# 🎯 Current focus (post-1.0.x)
 
 The next stage focuses on:
 


### PR DESCRIPTION
- Updated `CHANGELOG-PRERELEASES.md` to reference both stable releases `1.0.0` and `1.0.1`.
- Modified `README.md` to reflect the latest stable version as `1.0.1` and adjusted sections to clarify updates in the `1.0.x` line.
- Revised `ROADMAP.md` to indicate the current stable version as `1.0.1` and updated focus areas post-1.0.x.