### PR TITLE
Refactor translation strings for humidifier card

### DIFF
--- a/nodalia-humidifier-card.js
+++ b/nodalia-humidifier-card.js
@@ -911,22 +911,22 @@ function translateModeLabel(value, hass = null, configLang = null) {
       return "Auto";
     case "smart":
     case "smart_mode":
-      return "Inteligente";
+      return "Smart";
     case "sleep":
     case "night":
-      return "Noche";
+      return "Night";
     case "eco":
       return "Eco";
     case "quiet":
     case "silent":
-      return "Silencioso";
+      return "Quiet";
     case "low":
-      return "Baja";
+      return "Low";
     case "medium":
     case "mid":
-      return "Media";
+      return "Medium";
     case "high":
-      return "Alta";
+      return "High";
     case "boost":
       return "Boost";
     case "turbo":
@@ -936,12 +936,12 @@ function translateModeLabel(value, hass = null, configLang = null) {
       return "Normal";
     case "dry":
     case "drying":
-      return "Secado";
+      return "Dry";
     case "continuous":
-      return "Continuo";
+      return "Continuous";
     case "clothes_dry":
     case "laundry":
-      return "Ropa";
+      return "Laundry";
     default:
       return String(value ?? "");
   }
@@ -1265,7 +1265,7 @@ class NodaliaHumidifierCard extends HTMLElement {
     return this._config?.name
       || state?.attributes?.friendly_name
       || this._config?.entity
-      || "Humidificador";
+      || "Humidifier";
   }
 
   _getHumidifierIcon(state) {
@@ -1291,17 +1291,17 @@ class NodaliaHumidifierCard extends HTMLElement {
 
     switch (normalized) {
       case "on":
-        return "Encendido";
+        return "On";
       case "off":
-        return "Apagado";
+        return "Off";
       case "humidifying":
-        return "Humidificando";
+        return "Humidifying";
       case "dehumidifying":
-        return "Deshumidificando";
+        return "Dehumidifying";
       case "drying":
-        return "Secando";
+        return "Drying";
       case "idle":
-        return "En espera";
+        return "Idle";
       default:
         return state?.state ? String(state.state) : "";
     }

--- a/nodalia-i18n.js
+++ b/nodalia-i18n.js
@@ -6619,13 +6619,12 @@
   function translateHumidifierDeviceState(hass, configLang, rawValue) {
     const lang = resolveLanguage(hass, configLang);
     const k = normalizeTextKey(rawValue);
-    const dict = strings(lang).humidifierCard?.deviceStates || strings("en").humidifierCard?.deviceStates || {};
-    const en = strings("en").humidifierCard?.deviceStates || {};
+    const dict = {
+      ...(strings("en").humidifierCard?.deviceStates || {}),
+      ...(strings(lang).humidifierCard?.deviceStates || {}),
+    };
     if (k && dict[k]) {
       return dict[k];
-    }
-    if (k && en[k]) {
-      return en[k];
     }
     return String(rawValue ?? "").trim();
   }
@@ -6789,7 +6788,14 @@
   }
 
   function translateEntityState(langCode, state, numberDecimals, formatNumericValueWithUnit, formatNumericValue, parseNumericValue) {
-    const dict = strings(langCode).entityCard;
+    const ecEn = strings("en").entityCard || {};
+    const ecLoc = strings(langCode).entityCard || {};
+    const dict = {
+      ...ecEn,
+      ...ecLoc,
+      states: { ...(ecEn.states || {}), ...(ecLoc.states || {}) },
+      binarySensor: { ...(ecEn.binarySensor || {}), ...(ecLoc.binarySensor || {}) },
+    };
     if (!state) {
       return null;
     }


### PR DESCRIPTION
- Updated translation labels in `nodalia-humidifier-card.js` to use English terms for modes and states, enhancing consistency and clarity.
- Improved the internationalization logic in `nodalia-i18n.js` to merge language dictionaries, ensuring better fallback handling for device states and entity states.