### PR TITLE
Potential fix for code scanning alert no. 108: Bad HTML filtering regexp

### DIFF
--- a/tests/interaction-regressions.test.mjs
+++ b/tests/interaction-regressions.test.mjs
@@ -528,7 +528,7 @@ test("NodaliaUtils rejects CSS and markup injection in style values", () => {
   const document = renderCardEmptyStateDocument("<div class=\"test--empty\">Empty</div>", {
     card: { background: "red;} </style><script>alert(1)</script>" },
   });
-  assert.doesNotMatch(document, /<script>/);
+  assert.doesNotMatch(document, /<script\b[^>]*>/i);
   assert.match(document, /background: var\(--ha-card-background\)/);
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/danielmigueltejedor/nodalia-cards/security/code-scanning/108](https://github.com/danielmigueltejedor/nodalia-cards/security/code-scanning/108)

To fix this without changing functionality, update the test assertion regex on line 531 to a case-insensitive pattern that matches a script start tag robustly, not just the exact lowercase literal `<script>`.

Best single change in `tests/interaction-regressions.test.mjs`:
- Replace `assert.doesNotMatch(document, /<script>/);`
- With `assert.doesNotMatch(document, /<script\b[^>]*>/i);`

Why this is best:
- `i` handles uppercase/mixed-case tags.
- `\b` ensures matching the `script` tag name boundary.
- `[^>]*` allows attributes/whitespace before `>`, making the test stronger against realistic tag forms.
- It remains a minimal, local test-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
