### PR TITLE
Potential fix for code scanning alert no. 107: Incomplete string escaping or encoding

### DIFF
--- a/scripts/wrap-nav-editor-spans.mjs
+++ b/scripts/wrap-nav-editor-spans.mjs
@@ -131,7 +131,7 @@ c = c.replace(
 );
 
 for (const display of ["Anadir ruta", "Anadir player", "Anadir popup", "Subir", "Bajar", "Eliminar"]) {
-  const esc = display.replace(/"/g, '\\"');
+  const esc = display.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   c = c.split(`>${display}<`).join(`>\${this._L("${esc}")}<`);
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/danielmigueltejedor/nodalia-cards/security/code-scanning/107](https://github.com/danielmigueltejedor/nodalia-cards/security/code-scanning/107)

The correct fix is to escape backslashes **before** escaping double quotes in the `display` loop, just like the existing safer logic already used for `text` on line 117.

Best minimal fix (without changing behavior): update line 134 in `scripts/wrap-nav-editor-spans.mjs` from:

- `const esc = display.replace(/"/g, '\\"');`

to:

- `const esc = display.replace(/\\/g, "\\\\").replace(/"/g, '\\"');`

This preserves current functionality while making the escaping complete and consistent. No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
