### PR TITLE
test: tolerate eased animation samples

### DIFF
--- a/tests/browser/device-expansion-animations.spec.mjs
+++ b/tests/browser/device-expansion-animations.spec.mjs
@@ -63,6 +63,17 @@ const devices = [
   },
 ];
 
+const HEIGHT_SAMPLE_TOLERANCE_PX = 0.5;
+const MIN_TOTAL_HEIGHT_CHANGE_PX = 1;
+
+function expectHeightTrajectory(heights, direction) {
+  expect(heights).toHaveLength(3);
+  const signedHeights = heights.map(height => height * direction);
+  expect(signedHeights[1]).toBeGreaterThanOrEqual(signedHeights[0] - HEIGHT_SAMPLE_TOLERANCE_PX);
+  expect(signedHeights[2]).toBeGreaterThanOrEqual(signedHeights[1] - HEIGHT_SAMPLE_TOLERANCE_PX);
+  expect(signedHeights[2]).toBeGreaterThan(signedHeights[0] + MIN_TOTAL_HEIGHT_CHANGE_PX);
+}
+
 async function sampleAnimation(shell, animationName, expectedClass) {
   return shell.evaluate(async (element, expected) => {
     const nextFrame = () => new Promise(resolve => requestAnimationFrame(resolve));
@@ -171,8 +182,7 @@ for (const device of devices) {
     const opening = await sampleAnimation(openingShell, device.expandAnimation, device.entering);
     expect(opening.found).toBe(true);
     expect(opening.hadExpectedClass).toBe(true);
-    expect(opening.heights[1]).toBeGreaterThan(opening.heights[0] + 1);
-    expect(opening.heights[2]).toBeGreaterThan(opening.heights[1] + 1);
+    expectHeightTrajectory(opening.heights, 1);
     expect(opening.rows[0]).not.toBe(opening.rows[2]);
 
     await page.waitForTimeout(220);
@@ -197,8 +207,7 @@ for (const device of devices) {
     const closing = await sampleAnimation(closingShell, device.collapseAnimation, device.leaving);
     expect(closing.found).toBe(true);
     expect(closing.hadExpectedClass).toBe(true);
-    expect(closing.heights[1]).toBeLessThan(closing.heights[0] - 1);
-    expect(closing.heights[2]).toBeLessThan(closing.heights[1] - 1);
+    expectHeightTrajectory(closing.heights, -1);
 
     await page.waitForTimeout(220);
     await expect(card.locator(device.shell)).toHaveCount(0);


### PR DESCRIPTION
## What changed

- validate expansion and collapse samples through a shared signed-height trajectory helper
- allow `0.5px` of subpixel variance between intermediate samples
- retain a required total height change greater than `1px`

## Why

Cursor Bugbot correctly noted in #169 that the strong ease-out curve can leave the 50% and 85% samples less than one pixel apart on short control shells. The previous per-segment assertion could therefore be flaky even when the animation was correct.

## Impact

The browser regression still rejects missing, reversed, or effectively static animations, while no longer treating normal easing and subpixel layout as failures.

## Validation

- 40/40 WebKit and WebKit iPhone checks passed across five repetitions
- 431/431 Node tests passed
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to animation assertions; no production or runtime behavior is modified.
> 
> **Overview**
> Device expansion/collapse browser tests now assert height samples through a shared **`expectHeightTrajectory`** helper instead of requiring each consecutive sample to differ by more than **1px**.
> 
> The helper signs heights for expand (`direction` **1**) or collapse (**-1**), allows up to **0.5px** slack between the three samples (15% / 50% / 85% progress), and still requires the first-to-last height change to exceed **1px**. Missing, reversed, or flat animations should still fail; normal ease-out and subpixel layout should not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc07918e8e738d101a2db8ee79f464937f13ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->